### PR TITLE
DOC: removed a triple f in Difffusion.

### DIFF
--- a/docs/source/dti_batch.rst
+++ b/docs/source/dti_batch.rst
@@ -73,7 +73,7 @@ dti: Compute a tensor from diffusion data
        (Mask)              Binary mask to accelerate the fitting
     
      Outputs:
-       D                   [Dxx Dxy Dxz Dxy Dyy Dyz Dxz Dyz Dzz] Difffusion Tensor
+       D                   [Dxx Dxy Dxz Dxy Dyy Dyz Dxz Dyz Dzz] Diffusion Tensor
        L1                  1rst eigenvalue of D
        L2                  2nd eigenvalue of D
        L3                  3rd eigenvalue of D

--- a/src/Models/Diffusion/dti.m
+++ b/src/Models/Diffusion/dti.m
@@ -11,7 +11,7 @@ classdef dti < AbstractModel
 %   (Mask)              Binary mask to accelerate the fitting
 %
 % Outputs:
-%   D                   [Dxx Dxy Dxz Dxy Dyy Dyz Dxz Dyz Dzz] Difffusion Tensor
+%   D                   [Dxx Dxy Dxz Dxy Dyy Dyz Dxz Dyz Dzz] Diffusion Tensor
 %   L1                  1rst eigenvalue of D
 %   L2                  2nd eigenvalue of D
 %   L3                  3rd eigenvalue of D


### PR DESCRIPTION
There were 2 typos where the word `Diffusion` was written as `Difffusion`.