### PR TITLE
Faster linear fitting for VFA_T1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@
 language: java
 
 cache:
-
   apt: true # Not working for public repos :( 
   directories:
   # Following directories will be generated 
@@ -17,6 +16,7 @@ cache:
 env:
   global:
   - OCTAVE=octave
+  - WAIT_TIME=30
 before_install:
 # to prevent IPv6 being used for APT
 - travis_retry sudo apt-get -y -qq update
@@ -41,37 +41,186 @@ before_install:
 jobs:
   include:
   - stage: Test
-    script: if travis_wait 30 octave --no-gui --eval "bootstrapTest;cd('/home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible/quickMoxTests');res=moxunit_runtests('-recursive','-with_coverage','-cover','/home/travis/build/qMRLab/qMRLab/src','-cover_exclude','*GUI*','-cover_json_file','coverage_quickMoxTests.json');exit(~res);"; then aws s3 cp /home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible/quickMoxTests/coverage_quickMoxTests.json s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_quickMoxTests.json || travis_terminate 1; else travis_terminate 1; fi
+    script: 
+    - |
+      travis_wait $WAIT_TIME \
+      octave --no-gui --eval "bootstrapTest;cd('$TRAVIS_BUILD_DIR/Test/MoxUnitCompatible/quickMoxTests'); \
+      res=moxunit_runtests('-recursive','-with_coverage','-cover','$TRAVIS_BUILD_DIR/src','-cover_exclude','*GUI*','-cover_json_file','coverage_quickMoxTests.json'); \
+      exit(~res);"
+      if [ "$?" != "0" ]; then travis_terminate 1; fi
+      if [ "${TRAVIS_REPO_SLUG%%/*}" =  "qMRLab" ] 
+      then 
+        aws s3 cp $TRAVIS_BUILD_DIR/Test/MoxUnitCompatible/quickMoxTests/coverage_quickMoxTests.json \
+        s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_quickMoxTests.json;
+        if [ "$?" != "0" ]; then travis_terminate 1; fi
+      fi
   - stage: Test
-    script: if travis_wait 30 octave --no-gui --eval "bootstrapTest;cd('/home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible');res=moxunit_runtests('BatchExample_test.m','-with_coverage','-cover','/home/travis/build/qMRLab/qMRLab/src','-cover_exclude','*GUI*','-cover_json_file','coverage_BatchExample.json');exit(~res);"; then aws s3 cp /home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible/coverage_BatchExample.json s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_BatchExample.json || travis_terminate 1; else travis_terminate 1; fi
-  # Paste Sim_test commands below 
-  # Pay attention to the indentation! Make them look like -stage and script lines above.
+    script: 
+    - |
+      travis_wait $WAIT_TIME \
+      octave --no-gui --eval "bootstrapTest;cd('$TRAVIS_BUILD_DIR/Test/MoxUnitCompatible'); \
+      res=moxunit_runtests('BatchExample_test.m','-with_coverage','-cover','$TRAVIS_BUILD_DIR/src','-cover_exclude','*GUI*','-cover_json_file','coverage_BatchExample.json'); \
+      exit(~res);" 
+      if [ "$?" != "0" ]; then travis_terminate 1; fi
+      if [ "${TRAVIS_REPO_SLUG%%/*}" =  "qMRLab" ] 
+      then 
+        aws s3 cp $TRAVIS_BUILD_DIR/Test/MoxUnitCompatible/coverage_BatchExample.json \
+        s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_BatchExample.json
+        if [ "$?" != "0" ]; then travis_terminate 1; fi
+      fi
   - stage: Test
-    script: if travis_wait 30 octave --no-gui --eval "bootstrapTest;cd('/home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible');res=moxunit_runtests('BatchExample_qmt_spgr_test.m','-with_coverage','-cover','/home/travis/build/qMRLab/qMRLab/src','-cover_exclude','*GUI*','-cover_json_file','coverage_BatchExample_qmt_spgr.json');exit(~res);"; then aws s3 cp /home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible/coverage_BatchExample_qmt_spgr.json s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_BatchExample_qmt_spgr.json || travis_terminate 1; else travis_terminate 1; fi
+    script: 
+    - |
+      travis_wait $WAIT_TIME \
+      octave --no-gui --eval "bootstrapTest;cd('$TRAVIS_BUILD_DIR/Test/MoxUnitCompatible'); \
+      res=moxunit_runtests('BatchExample_qmt_spgr_test.m','-with_coverage','-cover','$TRAVIS_BUILD_DIR/src','-cover_exclude','*GUI*','-cover_json_file','coverage_BatchExample_qmt_spgr.json'); \
+      exit(~res);" 
+      if [ "$?" != "0" ]; then travis_terminate 1; fi
+      if [ "${TRAVIS_REPO_SLUG%%/*}" =  "qMRLab" ] 
+      then 
+        aws s3 cp $TRAVIS_BUILD_DIR/Test/MoxUnitCompatible/coverage_BatchExample_qmt_spgr.json \
+        s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_BatchExample_qmt_spgr.json
+        if [ "$?" != "0" ]; then travis_terminate 1; fi
+      fi
   - stage: Test
-    script: if travis_wait 30 octave --no-gui --eval "bootstrapTest;cd('/home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible');res=moxunit_runtests('BatchExample_qmt_bssfp_test.m','-with_coverage','-cover','/home/travis/build/qMRLab/qMRLab/src','-cover_exclude','*GUI*','-cover_json_file','coverage_BatchExample_qmt_bssfp.json');exit(~res);"; then aws s3 cp /home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible/coverage_BatchExample_qmt_bssfp.json s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_BatchExample_qmt_bssfp.json || travis_terminate 1; else travis_terminate 1; fi
+    script: 
+    - |
+      travis_wait $WAIT_TIME \
+      octave --no-gui --eval "bootstrapTest;cd('$TRAVIS_BUILD_DIR/Test/MoxUnitCompatible'); \
+      res=moxunit_runtests('BatchExample_qmt_bssfp_test.m','-with_coverage','-cover','$TRAVIS_BUILD_DIR/src','-cover_exclude','*GUI*','-cover_json_file','coverage_BatchExample_qmt_bssfp.json'); \
+      exit(~res);"
+      if [ "$?" != "0" ]; then travis_terminate 1; fi
+      if [ "${TRAVIS_REPO_SLUG%%/*}" =  "qMRLab" ] 
+      then 
+        aws s3 cp $TRAVIS_BUILD_DIR/Test/MoxUnitCompatible/coverage_BatchExample_qmt_bssfp.json \
+        s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_BatchExample_qmt_bssfp.json 
+        if [ "$?" != "0" ]; then travis_terminate 1; fi
+      fi
   - stage: Test
-    script: if travis_wait 30 octave --no-gui --eval "bootstrapTest;cd('/home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible');res=moxunit_runtests('BatchExample_qmt_sirfse_test.m','-with_coverage','-cover','/home/travis/build/qMRLab/qMRLab/src','-cover_exclude','*GUI*','-cover_json_file','coverage_BatchExample_qmt_sirfse.json');exit(~res);"; then aws s3 cp /home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible/coverage_BatchExample_qmt_sirfse.json s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_BatchExample_qmt_sirfse.json || travis_terminate 1; else travis_terminate 1; fi
+    script: 
+    - |
+      travis_wait $WAIT_TIME \
+      octave --no-gui --eval "bootstrapTest;cd('$TRAVIS_BUILD_DIR/Test/MoxUnitCompatible'); \
+      res=moxunit_runtests('BatchExample_qmt_sirfse_test.m','-with_coverage','-cover','$TRAVIS_BUILD_DIR/src','-cover_exclude','*GUI*','-cover_json_file','coverage_BatchExample_qmt_sirfse.json'); \
+      exit(~res);" 
+      if [ "$?" != "0" ]; then travis_terminate 1; fi
+      if [ "${TRAVIS_REPO_SLUG%%/*}" =  "qMRLab" ] 
+      then 
+        aws s3 cp $TRAVIS_BUILD_DIR/Test/MoxUnitCompatible/coverage_BatchExample_qmt_sirfse.json \
+        s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_BatchExample_qmt_sirfse.json; 
+        if [ "$?" != "0" ]; then travis_terminate 1; fi
+      fi
   - stage: Test
-    script: if travis_wait 30 octave --no-gui --eval "bootstrapTest;cd('/home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible');res=moxunit_runtests('SimTest_charmed.m','-with_coverage','-cover','/home/travis/build/qMRLab/qMRLab/src','-cover_exclude','*GUI*','-cover_json_file','coverage_SimTest_charmed.json');exit(~res);"; then aws s3 cp /home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible/coverage_SimTest_charmed.json s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_SimTest_charmed.json || travis_terminate 1; else travis_terminate 1; fi
+    script: 
+    - |
+      travis_wait $WAIT_TIME \
+      octave --no-gui --eval "bootstrapTest;cd('$TRAVIS_BUILD_DIR/Test/MoxUnitCompatible'); \
+      res=moxunit_runtests('SimTest_charmed.m','-with_coverage','-cover','$TRAVIS_BUILD_DIR/src','-cover_exclude','*GUI*','-cover_json_file','coverage_SimTest_charmed.json'); \
+      exit(~res);"
+      if [ "$?" != "0" ]; then travis_terminate 1; fi
+      if [ "${TRAVIS_REPO_SLUG%%/*}" =  "qMRLab" ] 
+      then 
+        aws s3 cp $TRAVIS_BUILD_DIR/Test/MoxUnitCompatible/coverage_SimTest_charmed.json \
+        s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_SimTest_charmed.json
+        if [ "$?" != "0" ]; then travis_terminate 1; fi
+      fi
   - stage: Test
-    script: if travis_wait 30 octave --no-gui --eval "bootstrapTest;cd('/home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible');res=moxunit_runtests('SimTest_dti.m','-with_coverage','-cover','/home/travis/build/qMRLab/qMRLab/src','-cover_exclude','*GUI*','-cover_json_file','coverage_SimTest_dti.json');exit(~res);"; then aws s3 cp /home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible/coverage_SimTest_dti.json s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_SimTest_dti.json || travis_terminate 1; else travis_terminate 1; fi
+    script: 
+    - |
+      travis_wait $WAIT_TIME \
+      octave --no-gui --eval "bootstrapTest;cd('$TRAVIS_BUILD_DIR/Test/MoxUnitCompatible'); \
+      res=moxunit_runtests('SimTest_dti.m','-with_coverage','-cover','$TRAVIS_BUILD_DIR/src','-cover_exclude','*GUI*','-cover_json_file','coverage_SimTest_dti.json'); \
+      exit(~res);"
+      if [ "$?" != "0" ]; then travis_terminate 1; fi
+      if [ "${TRAVIS_REPO_SLUG%%/*}" =  "qMRLab" ] 
+      then
+        aws s3 cp $TRAVIS_BUILD_DIR/Test/MoxUnitCompatible/coverage_SimTest_dti.json \
+        s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_SimTest_dti.json
+        if [ "$?" != "0" ]; then travis_terminate 1; fi
+      fi
   - stage: Test
-    script: if travis_wait 30 octave --no-gui --eval "bootstrapTest;cd('/home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible');res=moxunit_runtests('SimTest_noddi.m','-with_coverage','-cover','/home/travis/build/qMRLab/qMRLab/src','-cover_exclude','*GUI*','-cover_json_file','coverage_SimTest_noddi.json');exit(~res);"; then aws s3 cp /home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible/coverage_SimTest_noddi.json s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_SimTest_noddi.json || travis_terminate 1; else travis_terminate 1; fi
+    script: 
+    - |
+      travis_wait $WAIT_TIME \
+      octave --no-gui --eval "bootstrapTest;cd('$TRAVIS_BUILD_DIR/Test/MoxUnitCompatible'); \
+      res=moxunit_runtests('SimTest_noddi.m','-with_coverage','-cover','$TRAVIS_BUILD_DIR/src','-cover_exclude','*GUI*','-cover_json_file','coverage_SimTest_noddi.json'); \
+      exit(~res);"
+      if [ "$?" != "0" ]; then travis_terminate 1; fi
+      if [ "${TRAVIS_REPO_SLUG%%/*}" =  "qMRLab" ] 
+      then
+        aws s3 cp $TRAVIS_BUILD_DIR/Test/MoxUnitCompatible/coverage_SimTest_noddi.json \
+        s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_SimTest_noddi.json
+        if [ "$?" != "0" ]; then travis_terminate 1; fi
+      fi
   - stage: Test
-    script: if travis_wait 30 octave --no-gui --eval "bootstrapTest;cd('/home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible');res=moxunit_runtests('SimTest_qmt_sirfse.m','-with_coverage','-cover','/home/travis/build/qMRLab/qMRLab/src','-cover_exclude','*GUI*','-cover_json_file','coverage_SimTest_qmt_sirfse.json');exit(~res);"; then aws s3 cp /home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible/coverage_SimTest_qmt_sirfse.json s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_SimTest_mt_sirfse.json || travis_terminate 1; else travis_terminate 1; fi
+    script: 
+    - |
+      travis_wait $WAIT_TIME \
+      octave --no-gui --eval "bootstrapTest;cd('$TRAVIS_BUILD_DIR/Test/MoxUnitCompatible'); \
+      res=moxunit_runtests('SimTest_qmt_sirfse.m','-with_coverage','-cover','$TRAVIS_BUILD_DIR/src','-cover_exclude','*GUI*','-cover_json_file','coverage_SimTest_qmt_sirfse.json'); \
+      exit(~res);"
+      if [ "$?" != "0" ]; then travis_terminate 1; fi
+      if [ "${TRAVIS_REPO_SLUG%%/*}" =  "qMRLab" ] 
+      then
+        aws s3 cp $TRAVIS_BUILD_DIR/Test/MoxUnitCompatible/coverage_SimTest_qmt_sirfse.json \
+        s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_SimTest_mt_sirfse.json
+        if [ "$?" != "0" ]; then travis_terminate 1; fi
+      fi
   - stage: Test
-    script: if travis_wait 30 octave --no-gui --eval "bootstrapTest;cd('/home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible');res=moxunit_runtests('SimTest_inversion_recovery.m','-with_coverage','-cover','/home/travis/build/qMRLab/qMRLab/src','-cover_exclude','*GUI*','-cover_json_file','coverage_SimTest_inversion_recovery.json');exit(~res);"; then aws s3 cp /home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible/coverage_SimTest_inversion_recovery.json s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_SimTest_inversion_recovery.json || travis_terminate 1; else travis_terminate 1; fi
+    script: 
+    - |
+      travis_wait $WAIT_TIME \
+      octave --no-gui --eval "bootstrapTest;cd('$TRAVIS_BUILD_DIR/Test/MoxUnitCompatible'); \
+      res=moxunit_runtests('SimTest_inversion_recovery.m','-with_coverage','-cover','$TRAVIS_BUILD_DIR/src','-cover_exclude','*GUI*','-cover_json_file','coverage_SimTest_inversion_recovery.json'); \
+      exit(~res);"
+      if [ "$?" != "0" ]; then travis_terminate 1; fi
+      if [ "${TRAVIS_REPO_SLUG%%/*}" =  "qMRLab" ] 
+      then
+        aws s3 cp $TRAVIS_BUILD_DIR/Test/MoxUnitCompatible/coverage_SimTest_inversion_recovery.json \
+        s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_SimTest_inversion_recovery.json
+        if [ "$?" != "0" ]; then travis_terminate 1; fi
+      fi
   - stage: Test
-    script: if travis_wait 30 octave --no-gui --eval "bootstrapTest;cd('/home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible');res=moxunit_runtests('SimTest_vfa_t1.m','-with_coverage','-cover','/home/travis/build/qMRLab/qMRLab/src','-cover_exclude','*GUI*','-cover_json_file','coverage_SimTest_vfa_t1.json');exit(~res);"; then aws s3 cp /home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible/coverage_SimTest_vfa_t1.json s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_SimTest_vfa_t1.json || travis_terminate 1; else travis_terminate 1; fi
+    script: 
+    - |
+      travis_wait $WAIT_TIME \
+      octave --no-gui --eval "bootstrapTest;cd('$TRAVIS_BUILD_DIR/Test/MoxUnitCompatible'); \
+      res=moxunit_runtests('SimTest_vfa_t1.m','-with_coverage','-cover','$TRAVIS_BUILD_DIR/src','-cover_exclude','*GUI*','-cover_json_file','coverage_SimTest_vfa_t1.json'); \
+      exit(~res);"
+      if [ "$?" != "0" ]; then travis_terminate 1; fi
+      if [ "${TRAVIS_REPO_SLUG%%/*}" =  "qMRLab" ] 
+      then
+        aws s3 cp $TRAVIS_BUILD_DIR/Test/MoxUnitCompatible/coverage_SimTest_vfa_t1.json \
+        s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_SimTest_vfa_t1.json
+        if [ "$?" != "0" ]; then travis_terminate 1; fi
+      fi
   - stage: Test
-    script: if travis_wait 30 octave --no-gui --eval "bootstrapTest;cd('/home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible');res=moxunit_runtests('SimTest_mwf.m','-with_coverage','-cover','/home/travis/build/qMRLab/qMRLab/src','-cover_exclude','*GUI*','-cover_json_file','coverage_SimTest_mwf.json');exit(~res);"; then aws s3 cp /home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible/coverage_SimTest_mwf.json s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_SimTest_mwf.json || travis_terminate 1; else travis_terminate 1; fi
+    script: 
+    - |
+      travis_wait $WAIT_TIME \
+      octave --no-gui --eval "bootstrapTest;cd('$TRAVIS_BUILD_DIR/Test/MoxUnitCompatible'); \
+      res=moxunit_runtests('SimTest_mwf.m','-with_coverage','-cover','$TRAVIS_BUILD_DIR/src','-cover_exclude','*GUI*','-cover_json_file','coverage_SimTest_mwf.json'); \
+      exit(~res);"
+      if [ "$?" != "0" ]; then travis_terminate 1; fi
+      if [ "${TRAVIS_REPO_SLUG%%/*}" =  "qMRLab" ] 
+      then
+        aws s3 cp $TRAVIS_BUILD_DIR/Test/MoxUnitCompatible/coverage_SimTest_mwf.json \
+        s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_SimTest_mwf.json
+        if [ "$?" != "0" ]; then travis_terminate 1; fi
+      fi
   - stage: Test (no coverage)
-    script: travis_wait 30 octave --no-gui --eval "bootstrapTest;cd('/home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible');res=moxunit_runtests('SimTest_qmt_spgr.m');exit(~res);"
+    script: travis_wait $WAIT_TIME octave --no-gui --eval "bootstrapTest;cd('$TRAVIS_BUILD_DIR/Test/MoxUnitCompatible');res=moxunit_runtests('SimTest_qmt_spgr.m');exit(~res);"
   - stage: Test (no coverage)
-    script: travis_wait 30 octave --no-gui --eval "bootstrapTest;cd('/home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible');res=moxunit_runtests('SimTest_qmt_bssfp.m');exit(~res);"
+    script: travis_wait $WAIT_TIME octave --no-gui --eval "bootstrapTest;cd('$TRAVIS_BUILD_DIR/Test/MoxUnitCompatible');res=moxunit_runtests('SimTest_qmt_bssfp.m');exit(~res);"
   - stage: Send combined coveralls.io report
-    script: aws s3 cp s3://qmrlab/$TRAVIS_BUILD_NUMBER/ /home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible/ --recursive --include "*.json";octave --no-gui --eval "bootstrapTest;cd('/home/travis/build/qMRLab/qMRLab/');startup;mocov_combine('/home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible/','coverage_combined.json')";aws s3 cp /home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible/coverage_combined.json s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_combined.json;curl --verbose -F json_file=@/home/travis/build/qMRLab/qMRLab/Test/MoxUnitCompatible/coverage_combined.json https://coveralls.io/api/v1/jobs
-
+    if: fork = true
+    script: 
+    - |
+      aws s3 cp s3://qmrlab/$TRAVIS_BUILD_NUMBER/ $TRAVIS_BUILD_DIR/Test/MoxUnitCompatible/ --recursive --include "*.json"
+      octave --no-gui --eval "bootstrapTest;cd('$TRAVIS_BUILD_DIR/'); \
+        startup; \
+        mocov_combine('$TRAVIS_BUILD_DIR/Test/MoxUnitCompatible/','coverage_combined.json')"
+      aws s3 cp $TRAVIS_BUILD_DIR/Test/MoxUnitCompatible/coverage_combined.json s3://qmrlab/$TRAVIS_BUILD_NUMBER/coverage_combined.json
+      curl --verbose -F json_file=@$TRAVIS_BUILD_DIR/Test/MoxUnitCompatible/coverage_combined.json https://coveralls.io/api/v1/jobs
 after_failure:
   - sleep 10

--- a/src/Common/FitData.m
+++ b/src/Common/FitData.m
@@ -81,7 +81,7 @@ if Model.voxelwise % process voxelwise
     else
         Voxels = find(~computed)';
     end
-    l = length(Voxels);
+    numVox = length(Voxels);
 
     % Travis?
     if isempty(getenv('ISTRAVIS')) || ~str2double(getenv('ISTRAVIS')), ISTRAVIS=false; else ISTRAVIS=true; end
@@ -94,17 +94,17 @@ if Model.voxelwise % process voxelwise
         setappdata(h,'canceling',0)
     end
 
-    if (isempty(h)), j_progress('Fitting voxel ',l); end
-    for ii = 1:l
+    if (isempty(h)), fprintf('Fitting %d voxels.\n',numVox); end
+    for ii = 1:numVox
         vox = Voxels(ii);
 
         % Update waitbar
         if (isempty(h))
             % j_progress(ii) Feature removed temporarily until logs are implemented ? excessive printing is a nuissance in Jupyter Notebooks, and slow down processing
-%            fprintf('Fitting voxel %d/%d\r',ii,l);
+%            fprintf('Fitting voxel %d/%d\r',ii,numVox);
         else
             if getappdata(h,'canceling');  break;  end  % Allows user to cancel
-            waitbar(ii/l, h, sprintf('Fitting voxel %d/%d', ii, l));
+            waitbar(ii/numVox, h, sprintf('Fitting voxel %d/%d', ii, numVox));
         end
 
         % Get current voxel data

--- a/src/Models/T1_relaxometry/vfa_t1.m
+++ b/src/Models/T1_relaxometry/vfa_t1.m
@@ -102,7 +102,7 @@ end
             if (length(unique(TR))~=1), error('VFA data must have same TR'); end
             if ~isfield(data, 'B1map'), data.B1map = []; end
             if ~isfield(data, 'Mask'), data.Mask = []; end
-            [FitResult.M0, FitResult.T1] = Compute_M0_T1_OnSPGR(double(data.VFAData), flipAngles, TR(1), data.B1map, data.Mask);
+            [FitResult.T1, FitResult.M0] = Compute_M0_T1_OnSPGR(double(data.VFAData), flipAngles, TR(1), data.B1map, data.Mask);
        end
 
        function plotModel(obj,x,data)

--- a/src/Models/T1_relaxometry/vfa_t1.m
+++ b/src/Models/T1_relaxometry/vfa_t1.m
@@ -53,7 +53,7 @@ end
     properties
         MRIinputs = {'VFAData','B1map','Mask'};
         xnames = {'M0','T1'};
-        voxelwise = false; % New linear fit is used if this is set to false (the fit is still voxelwise) 
+        voxelwise = 0; % Fits are still voxelwise even when this is zero
 
         % Protocol
         Prot  = struct('VFAData',struct('Format',{{'FlipAngle' 'TR'}},...
@@ -93,7 +93,6 @@ end
             TR = obj.Prot.VFAData.Mat(1,2);
             E = exp(-TR/x.T1);
             Smodel = x.M0*sin(flipAngles/180*pi)*(1-E)./(1-E*cos(flipAngles/180*pi));
-
         end
 
        function FitResult = fit(obj,data)
@@ -101,12 +100,9 @@ end
             flipAngles = (obj.Prot.VFAData.Mat(:,1))';
             TR = obj.Prot.VFAData.Mat(:,2);
             if (length(unique(TR))~=1), error('VFA data must have same TR'); end
-            if ~isfield(data,'B1map'), data.B1map=1; end
-            if obj.voxelwise
-                [FitResult.M0, FitResult.T1] = mtv_compute_m0_t1(double(data.VFAData), flipAngles, TR(1), data.B1map);
-            else
-                [FitResult.M0, FitResult.T1] = Compute_M0_T1_OnSPGR(double(data.VFAData), flipAngles, TR(1), data.B1map, data.Mask);
-            end
+            if ~isfield(data, 'B1map'), data.B1map = []; end
+            if ~isfield(data, 'Mask'), data.Mask = []; end
+            [FitResult.M0, FitResult.T1] = Compute_M0_T1_OnSPGR(double(data.VFAData), flipAngles, TR(1), data.B1map, data.Mask);
        end
 
        function plotModel(obj,x,data)

--- a/src/Models/T1_relaxometry/vfa_t1.m
+++ b/src/Models/T1_relaxometry/vfa_t1.m
@@ -53,7 +53,7 @@ end
     properties
         MRIinputs = {'VFAData','B1map','Mask'};
         xnames = {'M0','T1'};
-        voxelwise = 1;
+        voxelwise = false; % New linear fit is used if this is set to false (the fit is still voxelwise) 
 
         % Protocol
         Prot  = struct('VFAData',struct('Format',{{'FlipAngle' 'TR'}},...
@@ -100,12 +100,13 @@ end
             % T1 and M0
             flipAngles = (obj.Prot.VFAData.Mat(:,1))';
             TR = obj.Prot.VFAData.Mat(:,2);
+            if (length(unique(TR))~=1), error('VFA data must have same TR'); end
             if ~isfield(data,'B1map'), data.B1map=1; end
-            [m0, t1] = mtv_compute_m0_t1(double(data.VFAData), flipAngles, TR(1), data.B1map);
-            FitResult.T1 = t1;
-            FitResult.M0 = m0;
-
-
+            if obj.voxelwise
+                [FitResult.M0, FitResult.T1] = mtv_compute_m0_t1(double(data.VFAData), flipAngles, TR(1), data.B1map);
+            else
+                [FitResult.M0, FitResult.T1] = Compute_M0_T1_OnSPGR(double(data.VFAData), flipAngles, TR(1), data.B1map, data.Mask);
+            end
        end
 
        function plotModel(obj,x,data)

--- a/src/Models_Functions/MTV/Compute_M0_T1_OnSPGR.m
+++ b/src/Models_Functions/MTV/Compute_M0_T1_OnSPGR.m
@@ -1,4 +1,4 @@
-function [M0, T1] = Compute_M0_T1_OnSPGR(data, flipAngles, TR, b1Map, roi, verbose)
+function [T1, M0] = Compute_M0_T1_OnSPGR(data, flipAngles, TR, b1Map, roi, verbose)
 %Perform a simple linear-least squares data fit on variable flip angle SPGR data 
 %
 % function [M0, T1] = Compute_M0_T1_OnSPGR(data, flipAngles, TR [, b1Map, roi, verbose])

--- a/src/Models_Functions/MTV/Compute_M0_T1_OnSPGR.m
+++ b/src/Models_Functions/MTV/Compute_M0_T1_OnSPGR.m
@@ -1,7 +1,7 @@
 function [M0, T1] = Compute_M0_T1_OnSPGR(data, flipAngles, TR, b1Map, roi, verbose)
 %Perform a simple linear-least squares data fit on variable flip angle SPGR data 
 %
-% function function [M0, T1] = Compute_M0_T1_OnSPGR(data, flipAngles, TR [, b1Map, roi, verbose])
+% function [M0, T1] = Compute_M0_T1_OnSPGR(data, flipAngles, TR [, b1Map, roi, verbose])
 % -----------------------------------------------------------
 % INPUTS:
 %   data: width x length x slices x flipAngles matrix
@@ -68,11 +68,10 @@ function [fittedSlope, fittedIntercept] = LinLeastSquares(x,y)
 % The second dimension could be different samples (e.g. voxels)
 
 if size(x)~=size(y), error('X and Y must have same size for linear fitting'); end
-% Compute covariances, i.e. cov(x,y) and cov(x,x)
+% Use the fact that slope = cov(x,y) / cov(x,x)
 lengthX = size(x,1);
 numerator = sum(x.*y) - sum(x).*sum(y) / lengthX;
 denominator = sum(x.^2) - sum(x).^2 / lengthX;
-% Slope is cov(x,y)/cov(x,x)
 fittedSlope = numerator ./ denominator;
 % Line of best fit has to pass through point (meanX, meanY)
 % Use this fact to get intecept

--- a/src/Models_Functions/MTV/Compute_M0_T1_OnSPGR.m
+++ b/src/Models_Functions/MTV/Compute_M0_T1_OnSPGR.m
@@ -1,0 +1,80 @@
+function [M0, T1] = Compute_M0_T1_OnSPGR(data, flipAngles, TR, b1Map, roi, verbose)
+%Perform a simple linear-least squares data fit on variable flip angle SPGR data 
+%
+% function function [M0, T1] = Compute_M0_T1_OnSPGR(data, flipAngles, TR [, b1Map, roi, verbose])
+% -----------------------------------------------------------
+% INPUTS:
+%   data: width x length x slices x flipAngles matrix
+%   flipAngles: vector of flip angles (in degrees) corresponding to last dimension of 'data'
+%   TR: Repetition time in seconds
+%   b1Map: width x length x slices matrix containing relative flip angle
+%         (i.e. if nominal alpha is 60 and measured alpha is 61, then b1Map = 61/60
+%   roi: width x length x slices binary mask 
+%   verbose: logical - for debugging
+
+
+if ndims(data)<3, data = permute(data(:),[2 3 4 1]); end
+[nX, nY, nZ, nFlip] = size(data);
+nVox = nX*nY*nZ;
+
+if (nargin < 4) || isempty(b1Map)
+    b1Map = ones(nX, nY, nZ);
+end
+
+if nargin<5 || isempty(roi)
+    roi = true(nX, nY, nZ);
+end
+
+if nargin<6
+    verbose = 0;
+end
+ 
+if length(b1Map) ~= length(data(:,:,:,1)), error('B1 size is different from data size'); end
+if ~islogical(roi), roi = roi>0; end
+
+% Reshape data into 2D array so that future steps are simpler
+data = reshape(data,[nVox nFlip])'; % Transpose because MATLAB is column-major
+data = data(:, roi(:));
+nVox = sum(roi(:));
+
+% Large matrix with redundant values will make computations faster,
+% but will also consume more memory
+alpha = deg2rad(flipAngles);
+if isrow(alpha), alpha = alpha'; end
+alpha = repmat(alpha,[1 nVox]) .* repmat(b1Map(roi(:))', [nFlip 1]);
+
+% Do the linear least squares fit
+y = data ./ sin(alpha);
+x = data ./ tan(alpha);
+[fittedSlope, fittedIntercept] = LinLeastSquares(x,y);
+
+% Assign arbitrary T1 value if fitted value in unphysical. 
+% Might be better to set this to NaN so users can identify voxels where fit fails
+arbitraryT1 = 0.000000000000001; % Arbitrary value in case fit fails
+fittedSlope(isnan(fittedSlope)) = arbitraryT1; 
+fittedIntercept(isnan(fittedIntercept)) = arbitraryT1;
+fittedSlope(fittedSlope<0) = arbitraryT1;
+
+[T1, M0] = deal(zeros(nX,nY,nZ));
+M0(roi(:)) = fittedIntercept ./ (1-fittedSlope);
+T1(roi(:)) = real(-TR./log(fittedSlope));
+end % END OF Compute_M0_T1_OnSPGR
+
+function [fittedSlope, fittedIntercept] = LinLeastSquares(x,y)
+% Simple linear least squares fit
+% Inputs:
+%   - x and y, arrays of equal sizes
+% The first dimension should contain the measurements
+% The second dimension could be different samples (e.g. voxels)
+
+if size(x)~=size(y), error('X and Y must have same size for linear fitting'); end
+% Compute covariances, i.e. cov(x,y) and cov(x,x)
+lengthX = size(x,1);
+numerator = sum(x.*y) - sum(x).*sum(y) / lengthX;
+denominator = sum(x.^2) - sum(x).^2 / lengthX;
+% Slope is cov(x,y)/cov(x,x)
+fittedSlope = numerator ./ denominator;
+% Line of best fit has to pass through point (meanX, meanY)
+% Use this fact to get intecept
+fittedIntercept = mean(y) - fittedSlope .* mean(x);
+end % END OF LinLeastSquares

--- a/src/Models_Functions/MTV/mtv_compute_m0_t1.m
+++ b/src/Models_Functions/MTV/mtv_compute_m0_t1.m
@@ -155,15 +155,3 @@ function M0=getM0fromT1(T1,TR,S,FA)
 ST=(1-exp(-TR./T1))./(1-cos(FA*pi/180).*exp(-TR./T1)).*sin(FA*pi/180);
 % M0=RP*PD (RP=Receiver Profile)
 M0=S/ST;
-
-function [fittedSlope, fittedIntercept] = crudeLinear(x,y)
-assert(size(x)==size(y), 'Size of x and y must match')
-assert(isvector(x), 'Linear fit can only be performed on two vectors');
-% Compute covariances, i.e. cov(x,y) and cov(x,x)
-numerator = sum(x.*y) - sum(x).*sum(y) / length(x);
-denominator = sum(x.^2) - sum(x).^2 / length(x);
-% Slope is cov(x,y)/cov(x,x)
-fittedSlope = numerator ./ denominator;
-% Line of best fit has to pass through point (meanX, meanY)
-% Use this fact to get intecept
-fittedIntercept = mean(y) - fitterSlope .* mean(x);


### PR DESCRIPTION
The current VFA_T1 fitting algorithm involves looping over each voxel and then calling `polyfit()` to do the linear fit. 
This PR proposes an algorithm that avoids using loops since they are notoriously slow in matlab.
This was based on code from @iveslevesque.

The table below shows the computation time needed to fit the example VFA dataset. The new algorithm takes 0.01 seconds for an entire slice containing 128x128 voxels. 
![image](https://user-images.githubusercontent.com/9019681/53259444-0d27fa80-369d-11e9-9e36-33cea5fffaec.png)
The percent difference between the maps from the new and old algorithm is in the order of 10E-11.
Tests for `vfa_t1` pass locally on Matlab R2017b, and the Travis build is successful for the fork/branch.
Wouldn't hurt for someone to double check that the same results are obtained using the new algorithm and that nothing new has broken.

**Additional notes**

- I don't know what the `voxelwise` setting is supposed to do. 
It seems that voxel-wise maps for VFA are produced regardless of whether `voxelwise` is `0` or `1`.
The only difference is that `voxelwise=1` has more overhead, so it is slower, and it takes the mask into account. So in the above table, the Master runtime with `voxelwise=0` is fitting all voxels regardless of whether a mask is supplied or not, which is why those runtimes don't depend on the mask. 
  + The PR version should apply the mask for both possible cases of `voxelwise`. The default value for `voxelwise` is changed to `0` since this is faster and yields the same result as using `voxelwise=1`. 
- Although the `mtv_compute_m0_t1()` function is replaced for VFA, it might still be used by other models and a few minor changes were made
  + Fixed issue where the function fails to run if both `roi` and `b1Map` are supplied. The `dataSize` variable was only defined when those inputs are missing/empty, but the variable is needed for later steps in the function.
  + It wasn't clear to me why `vfa_t1.Fit()` tries to assign a default value to the B1map when `mtv_compute_m0_t1()` has code that takes care of missing B1map---the latter ends up being unused in master.
    * The updated `vfa_t1.Fit()` in PR creates an empty B1map and Mask if they were not supplied by the user. This also ensures that a Mask is applied even when `voxelwise=0`.
  + The help comments indicate that the input data should be a matrix, yet the input is a vector when `voxelwise=1` and a faux matrix of 1x1x1xN is created instead. This happens in the PR too. I left this as it is because I don't know if the help comments are outdated and this is intended behaviour. 
- The new fitting function is placed in the same directory as `mtv_compute_m0_t1()`. Not sure if there is a better place for this, e.g. `src/Models_Functions/vfa_t1`
- The scripts in `travis.yml` contain hard-coded paths that won't work for forks, and the aws portion of the script will also fail. 
I modified the script so that the paths are no longer hard-coded and disabled the aws portion for forks.
Everything should still run normally if the build is triggered by the `qMRLab` organization---would have to verify this when this PR triggers a build. 
The scripts were also spread across multiple lines so that they're easier to read.
