### PR TITLE
[BUG] Resolve "Reference to non-existent field 'hdr'." bug when clicking the 3D viewer button

### DIFF
--- a/qMRLab.m
+++ b/qMRLab.m
@@ -822,8 +822,8 @@ I.img = handles.tool.getImage(1);
 I.label = cellstr(get(handles.SourcePop,'String'));
 Mask = handles.tool.getMask(1);
 if isfield(handles.CurrentData,'hdr')
-    tool = imtool3D_nii_3planes(I,Mask);
     I.hdr = handles.CurrentData.hdr;
+    tool = imtool3D_nii_3planes(I,Mask);
 else
     tool = imtool3D_3planes(I.img,Mask);
     for ii=1:3, tool(ii).setlabel(I.label); end


### PR DESCRIPTION
Hotfix for a bug I just encountered. Without it, I couldn't use the 3D viewer; switching the order of these two lines seems to resolve it fine for me.