### PR TITLE
Avoid printing unnecessary message

### DIFF
--- a/External/imtool3D_td/External/bids-matlab/+bids/+util/jsondecode.m
+++ b/External/imtool3D_td/External/bids-matlab/+bids/+util/jsondecode.m
@@ -19,6 +19,9 @@ elseif exist('spm_jsonread','file') == 3            % SPM12
     value = spm_jsonread(file, varargin{:});
 elseif exist('jsonread','file') == 3                % JSONio
     value = jsonread(file, varargin{:});
+elseif exist('loadjson','file') == 2                    % JSONlab
+    value = loadjson(file,varargin{:});
+
 else
     error('JSON library required: install JSONio from https://github.com/gllmflndn/JSONio');
 end

--- a/External/imtool3D_td/External/bids-matlab/+bids/+util/jsonencode.m
+++ b/External/imtool3D_td/External/bids-matlab/+bids/+util/jsonencode.m
@@ -55,8 +55,7 @@ elseif exist('jsonencode','builtin') == 5                % MATLAB >= R2016b
     end
     varargout = { txt };
 
-elseif exist('savejson','file') == 2   
-    disp('this');                 % JSONlab
+elseif exist('savejson','file') == 2                 % JSONlab
     [varargout{1:nargout}] = savejson(varargin{:});
 
 else

--- a/External/imtool3D_td/External/bids-matlab/+bids/+util/jsonencode.m
+++ b/External/imtool3D_td/External/bids-matlab/+bids/+util/jsonencode.m
@@ -54,6 +54,11 @@ elseif exist('jsonencode','builtin') == 5                % MATLAB >= R2016b
         fclose(fid);
     end
     varargout = { txt };
+
+elseif exist('savejson','file') == 2   
+    disp('this');                 % JSONlab
+    [varargout{1:nargout}] = savejson(varargin{:});
+
 else
     error('JSON library required: install JSONio from https://github.com/gllmflndn/JSONio');
 end

--- a/src/Common/FitResultsSave_mat.m
+++ b/src/Common/FitResultsSave_mat.m
@@ -6,6 +6,12 @@ function FitResultsSave_mat(FitResults,folder)
 % Example:
 %   FitResultsSave_nii(FitResults,'merged_crop_eddy_moco.nii')
 if ~exist('folder','var'), folder = 'FitResults'; end
+
+if length(strfind(folder,filesep)) <= 1 && length(strfind(folder,['.' filesep]))~=1
+    folder = [pwd filesep folder];
+    mkdir(folder);
+end
+
 if ~exist(folder,'dir')
     mkdir(folder)
 end

--- a/src/Common/FitResultsSave_mat.m
+++ b/src/Common/FitResultsSave_mat.m
@@ -8,11 +8,21 @@ function FitResultsSave_mat(FitResults,folder)
 if ~exist('folder','var'), folder = 'FitResults'; end
 
 if length(strfind(folder,filesep)) <= 1 && length(strfind(folder,['.' filesep]))~=1
+% Normally users should pass folder variable in the ./myDir format to create folder
+% myDir at their current directory. This condition guards against users who pass
+% folder without './' expression preceding the folder name (e.g. myDir or /myDir).
+% The conditional statement checks for the existence of this case, if present, 
+% it prepends absolute path of the pwd to the folder name to ensure that 
+% the folder is created without possibly conflicting with another folder that may 
+% be saved in the MATLAB/Octave's search path (e.g. Test).
+
     folder = [pwd filesep folder];
     mkdir(folder);
 end
 
 if ~exist(folder,'dir')
+% Avoids warnings to amazing users who would like to save somehting to an 
+% existing directory using absolute path.   
     mkdir(folder)
 end
 

--- a/src/Common/FitResultsSave_mat.m
+++ b/src/Common/FitResultsSave_mat.m
@@ -6,7 +6,10 @@ function FitResultsSave_mat(FitResults,folder)
 % Example:
 %   FitResultsSave_nii(FitResults,'merged_crop_eddy_moco.nii')
 if ~exist('folder','var'), folder = 'FitResults'; end
-mkdir(folder)
+if ~exist(folder,'dir')
+    mkdir(folder)
+end
+
 for i = 1:length(FitResults.fields)
     map = FitResults.fields{i};
     file = strcat(map,'.mat');

--- a/src/Common/FitResultsSave_nii.m
+++ b/src/Common/FitResultsSave_nii.m
@@ -6,8 +6,14 @@ function FitResultsSave_nii(FitResults,fname_copyheader,folder)
 % Example:
 %   FitResultsSave_nii(FitResults,'merged_crop_eddy_moco.nii')
 if ~exist('folder','var'), folder = 'FitResults'; end
+
+if length(strfind(folder,filesep)) <= 1 && length(strfind(folder,['.' filesep]))~=1
+    folder = [pwd filesep folder];
+    mkdir(folder);
+end
+
 if ~exist(folder,'dir')
-    mkdir(folder)
+    mkdir(folder); 
 end
 
 

--- a/src/Common/FitResultsSave_nii.m
+++ b/src/Common/FitResultsSave_nii.m
@@ -6,7 +6,11 @@ function FitResultsSave_nii(FitResults,fname_copyheader,folder)
 % Example:
 %   FitResultsSave_nii(FitResults,'merged_crop_eddy_moco.nii')
 if ~exist('folder','var'), folder = 'FitResults'; end
-mkdir(folder)
+if ~exist(folder,'dir')
+    mkdir(folder)
+end
+
+
 for i = 1:length(FitResults.fields)
     map = FitResults.fields{i};
     file = strcat(map,'.nii.gz');

--- a/src/Common/FitResultsSave_nii.m
+++ b/src/Common/FitResultsSave_nii.m
@@ -8,11 +8,21 @@ function FitResultsSave_nii(FitResults,fname_copyheader,folder)
 if ~exist('folder','var'), folder = 'FitResults'; end
 
 if length(strfind(folder,filesep)) <= 1 && length(strfind(folder,['.' filesep]))~=1
+% Normally users should pass folder variable in the ./myDir format to create folder
+% myDir at their current directory. This condition guards against users who pass
+% folder without './' expression preceding the folder name (e.g. myDir or /myDir).
+% The conditional statement checks for the existence of this case, if present, 
+% it prepends absolute path of the pwd to the folder name to ensure that 
+% the folder is created without possibly conflicting with another folder that may 
+% be saved in the MATLAB/Octave's search path (e.g. Test).
+    
     folder = [pwd filesep folder];
     mkdir(folder);
 end
 
 if ~exist(folder,'dir')
+% Avoids warnings to amazing users who would like to save somehting to an 
+% existing directory using absolute path.    
     mkdir(folder); 
 end
 


### PR DESCRIPTION
FitResultsSave nii or mat attempts to create a dir that already exists when save path is passed as variable. 

This PR introduces a small fix for that. 