### PR TITLE
Add option of old voxelwise algorithm for VFA

### DIFF
--- a/src/Models/T1_relaxometry/vfa_t1.m
+++ b/src/Models/T1_relaxometry/vfa_t1.m
@@ -99,10 +99,17 @@ end
             % T1 and M0
             flipAngles = (obj.Prot.VFAData.Mat(:,1))';
             TR = obj.Prot.VFAData.Mat(:,2);
-            if (length(unique(TR))~=1), error('VFA data must have same TR'); end
-            if ~isfield(data, 'B1map'), data.B1map = []; end
-            if ~isfield(data, 'Mask'), data.Mask = []; end
-            [FitResult.T1, FitResult.M0] = Compute_M0_T1_OnSPGR(double(data.VFAData), flipAngles, TR(1), data.B1map, data.Mask);
+            if obj.voxelwise == 0
+                if (length(unique(TR))~=1), error('VFA data must have same TR'); end
+                if ~isfield(data, 'B1map'), data.B1map = []; end
+                if ~isfield(data, 'Mask'), data.Mask = []; end
+                [FitResult.T1, FitResult.M0] = Compute_M0_T1_OnSPGR(double(data.VFAData), flipAngles, TR(1), data.B1map, data.Mask);
+            elseif obj.voxelwise == 1
+                if ~isfield(data,'B1map'), data.B1map=1; end
+                [m0, t1] = mtv_compute_m0_t1(double(data.VFAData), flipAngles, TR(1), data.B1map);
+                FitResult.T1 = t1;
+                FitResult.M0 = m0;
+            end
        end
 
        function plotModel(obj,x,data)


### PR DESCRIPTION
Previously we switched from a voxelwise to linearized algorithm for VFA: https://github.com/qMRLab/qMRLab/commit/f03e5a0ead4c0ff94d3c25bd7a4502948b1d22d0

While this algorithm works pretty much as well as the old one only faster, there is a small difference that I just hit upon while trying to reproduce my interactive VFA notebook with the latest master branch (it used to point to a 2 year old commit).

Basically, the new algorithm has more circumstances that can lead to NaNs, and for most users in doesn't really matter, but I hit these more in my VFA notebook because I do some low SNR and/or really bad B1 simulations in it. To reproduce the graphs from my book chapter / notebook, the change in this PR is needed to give me the option of using the old algorithm (which can be selected by changing the voxelwise mode).