### PR TITLE
Bug built-in matlab sinc function

### DIFF
--- a/src/Common/pulse/sinc_fn.m
+++ b/src/Common/pulse/sinc_fn.m
@@ -1,4 +1,4 @@
-function y = sinc(x)
+function y = sinc_fn(x)
 
 i=find(x==0);                                                              
 x(i)= 1;                       

--- a/src/Common/pulse/sinc_pulse.m
+++ b/src/Common/pulse/sinc_pulse.m
@@ -32,7 +32,7 @@ else
     TBW = PulseOpt.TBW;
 end
 
-pulse = sinc( TBW/Trf * (t - Trf/2) );
+pulse = sinc_fn( TBW/Trf * (t - Trf/2) );
 pulse((t < 0 | t>Trf)) = 0;
 
 end


### PR DESCRIPTION
## Purpose
Solution to issue #46.

## Approach
Rename the `sinc` function that qMRLab uses.

#### Open Questions and Pre-Merge TODOs
- [ ] Use github checklists. When solved, check the box and explain the answer.

- [ ] Review that changed source files/lines are related to the pull request/issue
_If any files/commits were accidentally included, cherry-pick them into another branch._

- [ ] Review that changed source files/lines were not accidentally deleted
_Fix appropriately if so._

- [ ] Test new features or bug fix
_If not implemented/resolved adequately, solve it or inform the developer by requesting changes in your review._
_Preferably, set breakpoints in the locations that the code was changed and follow allong line by line to see if the code behaves as intended._

##### Manual GUI tests (general)

- [ ] Does the qMRLab GUI open?
- [ ] Can you change models?
- [ ] Can you load a data folder for a model?
- [ ] Can you view data?
- [ ] Can you zoom in the image?
- [ ] Can you pan out of the image?
- [ ] Can you view the histogram of the data?
- [ ] Can you change the color map?
- [ ] Can you fit dataset (Fit data)?
- [ ] Can you save/load the results?
- [ ] Can you open the options panel?
- [ ] Can you change option parameters?
- [ ] Can you save/load option paramters?
- [ ] Can you select a voxel?
- [ ] Can you fit the data of that voxel ("View data fit")?
- [ ] Can you simulate and fit a voxel ("Single Voxel Curve")?
- [ ] Can you run a Sensitivity Analysis?
- [ ] Can you simulate a Multi Voxel Distribution?

##### Specifications

  - Version:
  - Platform:
  - Subsystem:
