### PR TITLE
[Patch] Default B1 filter for AFI doesn't work on octave

### DIFF
--- a/src/Models/FieldMaps/b1_afi.m
+++ b/src/Models/FieldMaps/b1_afi.m
@@ -84,7 +84,9 @@ classdef b1_afi < AbstractModel & FilterClass
             
             % call the superclass (FilterClass) fit function
             data.Raw = B1map_nospur;
-            FitResult.B1map_filtered=cell2mat(struct2cell(fit@FilterClass(obj,data,[obj.options.Smoothingfilter_sizex,obj.options.Smoothingfilter_sizey,obj.options.Smoothingfilter_sizez])));
+            if ~moxunit_util_platform_is_octave
+                FitResult.B1map_filtered=cell2mat(struct2cell(fit@FilterClass(obj,data,[obj.options.Smoothingfilter_sizex,obj.options.Smoothingfilter_sizey,obj.options.Smoothingfilter_sizez])));
+            end
             % note: can't use struct2array because dne for octave...
         end
     end


### PR DESCRIPTION
## Purpose
For the AFI module/blog post, the default B1 filter setup doesn't run on octave due to incompatibilities, so this patches it such that the output isn't filtered and saved if it's running on Octave.


#### Open Questions and Pre-Merge TODOs
- [ ] Use github checklists. When solved, check the box and explain the answer.

- [x] Review that changed source files/lines are related to the pull request/issue
_If any files/commits were accidentally included, cherry-pick them into another branch._

- [x] Review that changed source files/lines were not accidentally deleted
_Fix appropriately if so._

- [x] Test new features or bug fix
_If not implemented/resolved adequately, solve it or inform the developer by requesting changes in your review._
_Preferably, set breakpoints in the locations that the code was changed and follow allong line by line to see if the code behaves as intended._

##### Manual GUI tests (general)

- [x] Does the qMRLab GUI open?
- [x] Can you change models?
- [x] Can you load a data folder for a model?
- [x] Can you view data?
- [x] Can you zoom in the image?
- [x] Can you pan out of the image?
- [x] Can you view the histogram of the data?
- [x] Can you change the color map?
- [x] Can you fit dataset (Fit data)?
- [x] Can you save/load the results?
- [x] Can you open the options panel?
- [x] Can you change option parameters?
- [x] Can you save/load option paramters?
- [x] Can you select a voxel?
- [x] Can you fit the data of that voxel ("View data fit")?
- [x] Can you simulate and fit a voxel ("Single Voxel Curve")?
- [x] Can you run a Sensitivity Analysis?
- [x] Can you simulate a Multi Voxel Distribution?

##### Specifications

  - Version:
  - Platform:
  - Subsystem:
