### PR TITLE
Bug fixed : bounds for fitting mono T2

### DIFF
--- a/src/Models/T2_relaxometry/mono_t2.m
+++ b/src/Models/T2_relaxometry/mono_t2.m
@@ -77,6 +77,15 @@ end
             Smodel = x.M0.*exp(-obj.Prot.SEdata.Mat./x.T2);
         end
         
+        function obj = UpdateFields(obj)
+            if obj.fx(1)
+               obj.fx = [1 1];
+            else
+               obj.fx = [0 0];
+            end
+                        
+        end
+        
         function FitResults = fit(obj,data)
             %  Fit data using model equation.
             %  data is a structure. FieldNames are based on property
@@ -131,10 +140,18 @@ end
                 options.Algorithm = 'levenberg-marquardt';
                 options.Display = 'off';
                 
-                if obj.options.OffsetTerm
-                    fit_out = lsqnonlin(fT2,[pdInit t2Init 0],[],[],options);
+                if any(obj.fx)
+                    if obj.options.OffsetTerm
+                        fit_out = lsqnonlin(fT2,[pdInit t2Init 0],[obj.lb(2), obj.lb(1)],[obj.ub(2), obj.ub(1)],options);
+                    else
+                        fit_out = lsqnonlin(fT2,[pdInit t2Init],[obj.lb(2) obj.lb(1)],[obj.ub(2) obj.ub(1)],options);
+                    end
                 else
-                    fit_out = lsqnonlin(fT2,[pdInit t2Init],[],[],options);
+                    if obj.options.OffsetTerm
+                        fit_out = lsqnonlin(fT2,[pdInit t2Init 0],[],[],options);
+                    else
+                        fit_out = lsqnonlin(fT2,[pdInit t2Init],[],[],options);
+                    end
                 end
                 
                 FitResults.T2 = fit_out(2);

--- a/src/Models/T2_relaxometry/mono_t2.m
+++ b/src/Models/T2_relaxometry/mono_t2.m
@@ -48,7 +48,7 @@ end
         st           = [ 100	1000 ]; % starting point
         lb            = [  1      1 ]; % lower bound
         ub           = [ 300        10000 ]; % upper bound
-        fx            = [ 0       0 ]; % fix parameters
+        fx            = [ 0       0]; % fix parameters
         
         % Protocol
         Prot  = struct('SEdata',struct('Format',{{'EchoTime (ms)'}},...
@@ -76,15 +76,19 @@ end
             % equation
             Smodel = x.M0.*exp(-obj.Prot.SEdata.Mat./x.T2);
         end
-        
+
         function obj = UpdateFields(obj)
             if obj.fx(1)
-               obj.fx = [1 1];
-            else
-               obj.fx = [0 0];
+                obj.lb(1) = obj.st(1);
+                obj.ub(1) = obj.st(1);
             end
-                        
-        end
+            
+            if obj.fx(2)
+                obj.lb(2) = obj.st(2);
+                obj.ub(2) = obj.st(2);
+            end
+             
+         end
         
         function FitResults = fit(obj,data)
             %  Fit data using model equation.
@@ -140,19 +144,12 @@ end
                 options.Algorithm = 'levenberg-marquardt';
                 options.Display = 'off';
                 
-                if any(obj.fx)
-                    if obj.options.OffsetTerm
-                        fit_out = lsqnonlin(fT2,[pdInit t2Init 0],[obj.lb(2), obj.lb(1)],[obj.ub(2), obj.ub(1)],options);
-                    else
-                        fit_out = lsqnonlin(fT2,[pdInit t2Init],[obj.lb(2) obj.lb(1)],[obj.ub(2) obj.ub(1)],options);
-                    end
+                if obj.options.OffsetTerm
+                    fit_out = lsqnonlin(fT2,[pdInit t2Init 0],[obj.lb(2), obj.lb(1)],[obj.ub(2), obj.ub(1)],options);
                 else
-                    if obj.options.OffsetTerm
-                        fit_out = lsqnonlin(fT2,[pdInit t2Init 0],[],[],options);
-                    else
-                        fit_out = lsqnonlin(fT2,[pdInit t2Init],[],[],options);
-                    end
+                    fit_out = lsqnonlin(fT2,[pdInit t2Init],[obj.lb(2) obj.lb(1)],[obj.ub(2) obj.ub(1)],options);
                 end
+
                 
                 FitResults.T2 = fit_out(2);
                 FitResults.M0 = fit_out(1);

--- a/src/Models/T2_relaxometry/mono_t2.m
+++ b/src/Models/T2_relaxometry/mono_t2.m
@@ -67,7 +67,7 @@ end
         function obj = mono_t2()
             
             obj.options = button2opts(obj.buttons);
-            obj.onlineData_url = obj.getLink('https://osf.io/kujp3/download?version=2','https://osf.io/ns3wx/download?version=1','https://osf.io/kujp3/download?version=2');
+            obj.onlineData_url = obj.getLink('https://osf.io/kujp3/download?version=3','https://osf.io/ns3wx/download?version=2','https://osf.io/kujp3/download?version=3');
         end
         
         function Smodel = equation(obj, x)


### PR DESCRIPTION
## Purpose
Upper and lower bounds aren't apply during the mono T2 fitting

## Approach
Modify the mono T2 file accordingly, also fix checkbox was not working before, and now M0 is forced to be fixed when T2 is fixed.

#### Open Questions and Pre-Merge TODOs
- [x] Use github checklists. When solved, check the box and explain the answer.

- [x] Review that changed source files/lines are related to the pull request/issue
_If any files/commits were accidentally included, cherry-pick them into another branch._

- [x] Review that changed source files/lines were not accidentally deleted
_Fix appropriately if so._

- [x] Test new features or bug fix
_If not implemented/resolved adequately, solve it or inform the developer by requesting changes in your review._
_Preferably, set breakpoints in the locations that the code was changed and follow allong line by line to see if the code behaves as intended._

##### Manual GUI tests (general)

- [x] Does the qMRLab GUI open?
- [x] Can you change models?
- [x] Can you load a data folder for a model?
- [x] Can you view data?
- [x] Can you zoom in the image?
- [x] Can you pan out of the image?
- [x] Can you view the histogram of the data?
- [x] Can you change the color map?
- [x] Can you fit dataset (Fit data)?
- [x] Can you save/load the results?
- [x] Can you open the options panel?
- [x] Can you change option parameters?
- [x] Can you save/load option paramters?
- [x] Can you select a voxel?
- [x] Can you fit the data of that voxel ("View data fit")?
- [x] Can you simulate and fit a voxel ("Single Voxel Curve")?
- [x] Can you run a Sensitivity Analysis?
- [x] Can you simulate a Multi Voxel Distribution?
