### PR TITLE
Fix nifti scaling bug when saving qMRI maps

### DIFF
--- a/qMRLab.m
+++ b/qMRLab.m
@@ -532,6 +532,13 @@ for ii = 1:length(FitResults.fields)
     if ~exist('hdr','var')
         save_nii(make_nii(FitResults.(map)),fullfile(outputdir,file));
     else
+        % Reset multiplicative and additive scale factors to nifti header
+        % in case there were some in the input file's header that was used
+        % as a template. If this isn't done, then when a tool loads the
+        % qMRI map's nifti file, it will apply an undesired scaling.
+        hdr.scl_slope = 1;
+        hdr.scl_inter = 0;
+	
         nii_save(FitResults.(map),hdr,fullfile(outputdir,file));
     end
 end


### PR DESCRIPTION
Fixes a bug where if the input file used as a template has a scaling factor set within the nifti file, the saved nii qMRI map would inherit this scaling factor, causing issues when the nii qMRI map would be loaded in this tool or another tool (due to the scaling being applied).