### PR TITLE
Fix isempty bug for doc data download

### DIFF
--- a/src/Common/AbstractModel.m
+++ b/src/Common/AbstractModel.m
@@ -460,7 +460,7 @@ classdef (Abstract) AbstractModel
                 URL  = urlFull;
             end
 
-            if exist('docException','var') &&  ~isempty(str2double(getenv('ISDOC')))
+            if exist('docException','var') &&  ~isempty(getenv('ISDOC'))
                 try
                     URL = docException;
                 catch


### PR DESCRIPTION
I found this bug through the qsm_sb model.

Basically, when using the GUI, downloading the demo qsm_sb data results in the partial dataset being downloaded and not the full dataset.

This is because although `getenv('ISDOC')` is an empty char array, a `str2double()` of a char array results in a NaN, not an empty value, and thus `~isempty(str2double(getenv('ISDOC')))` is true even when not in a `ISDOC` env.

