### PR TITLE
Correct excitation flip angles in R1 and A calculations when B1 input exists

### DIFF
--- a/src/Models_Functions/MTSATfun/MTSAT_exec.m
+++ b/src/Models_Functions/MTSATfun/MTSAT_exec.m
@@ -24,21 +24,32 @@ Alpha_B1 = B1Params(1);
 Inds = find(PDw_data & T1w_data & MTw_data);
 MTsat = double(zeros(size(MTw_data)));
 
-% check if a T1 map was given in input; if not, compute it
-R1(Inds) = 0.5*((alpha_T1/TR_T1)*T1w_data(Inds)  - (alpha_PD/TR_PD)*PDw_data(Inds))./(PDw_data(Inds)/alpha_PD - T1w_data(Inds)/alpha_T1);
-
-% compute A
-A = (TR_PD*alpha_T1/alpha_PD - TR_T1*alpha_PD/alpha_T1)*((PDw_data(Inds).*T1w_data(Inds))./(TR_PD*alpha_T1*T1w_data(Inds) - TR_T1*alpha_PD*PDw_data(Inds)));
-
-% preallocate and compute MTsat; percent units
-MTsat(Inds) = 100 * (TR_MT*(alpha_MT*(A./MTw_data(Inds)) - ones(size(MTw_data(Inds)))).*R1(Inds) - (alpha_MT^2)/2);
-
 % Apply B1 correction to result
 if isfield(data,'B1map') && ~isempty(data.B1map)
 	if any(size(data.B1map) ~= size(MTsat)), error('\nError in MTSAT_exec.m: B1 map dimension different from volume dimension.\n'); end
 
-% Weiskopf, N., Suckling, J., Williams, G., Correia, M.M., Inkster, B., Tait, R., Ooi, C., Bullmore, E.T., Lutti, A., 2013. Quantitative multi-parameter mapping of R1, PD(*), MT, and R2(*) at 3T: a multi-center validation. Front. Neurosci. 7, 95.
+    % check if a T1 map was given in input; if not, compute it
+    R1(Inds) = 0.5.*((alpha_T1.*data.B1map(Inds)./TR_T1).*T1w_data(Inds)  - (alpha_PD*data.B1map(Inds)./TR_PD).*PDw_data(Inds))./(PDw_data(Inds)./(alpha_PD*data.B1map(Inds)) - T1w_data(Inds)./(alpha_T1*data.B1map(Inds)));
+    
+    % compute A
+    A = (TR_PD.*alpha_T1.*data.B1map(Inds)./(alpha_PD.*data.B1map(Inds)) - TR_T1.*alpha_PD.*data.B1map(Inds)./(alpha_T1.*data.B1map(Inds))).*((PDw_data(Inds).*T1w_data(Inds))./(TR_PD.*(alpha_T1.*data.B1map(Inds)).*T1w_data(Inds) - TR_T1.*(alpha_PD.*data.B1map(Inds)).*PDw_data(Inds)));
+	
+    % preallocate and compute MTsat; percent units
+    MTsat(Inds) = 100 * (TR_MT.*((alpha_MT.*data.B1map(Inds)).*(A./MTw_data(Inds)) - ones(size(MTw_data(Inds)))).*R1(Inds) - ((alpha_MT.*data.B1map(Inds)).^2)./2);
+
+    % Weiskopf, N., Suckling, J., Williams, G., Correia, M.M., Inkster, B., Tait, R., Ooi, C., Bullmore, E.T., Lutti, A., 2013. Quantitative multi-parameter mapping of R1, PD(*), MT, and R2(*) at 3T: a multi-center validation. Front. Neurosci. 7, 95.
     MTsat = MTsat .* (1 - Alpha_B1)./(1 - Alpha_B1 * data.B1map);
+
+else
+    % check if a T1 map was given in input; if not, compute it
+    R1(Inds) = 0.5*((alpha_T1/TR_T1)*T1w_data(Inds)  - (alpha_PD/TR_PD)*PDw_data(Inds))./(PDw_data(Inds)/alpha_PD - T1w_data(Inds)/alpha_T1);
+
+    % compute A
+    A = (TR_PD*alpha_T1/alpha_PD - TR_T1*alpha_PD/alpha_T1)*((PDw_data(Inds).*T1w_data(Inds))./(TR_PD*alpha_T1*T1w_data(Inds) - TR_T1*alpha_PD*PDw_data(Inds)));
+
+    % preallocate and compute MTsat; percent units
+    MTsat(Inds) = 100 * (TR_MT*(alpha_MT*(A./MTw_data(Inds)) - ones(size(MTw_data(Inds)))).*R1(Inds) - (alpha_MT^2)/2);
+
 end
 
 % Mask

--- a/src/Models_Functions/MTSATfun/MTSAT_exec.m
+++ b/src/Models_Functions/MTSATfun/MTSAT_exec.m
@@ -35,7 +35,7 @@ if isfield(data,'B1map') && ~isempty(data.B1map)
     A = (TR_PD.*alpha_T1.*data.B1map(Inds)./(alpha_PD.*data.B1map(Inds)) - TR_T1.*alpha_PD.*data.B1map(Inds)./(alpha_T1.*data.B1map(Inds))).*((PDw_data(Inds).*T1w_data(Inds))./(TR_PD.*(alpha_T1.*data.B1map(Inds)).*T1w_data(Inds) - TR_T1.*(alpha_PD.*data.B1map(Inds)).*PDw_data(Inds)));
 	
     % preallocate and compute MTsat; percent units
-    MTsat(Inds) = 100 * (TR_MT.*((alpha_MT.*data.B1map(Inds)).*(A./MTw_data(Inds)) - ones(size(MTw_data(Inds)))).*R1(Inds) - ((alpha_MT.*data.B1map(Inds)).^2)./2);
+    MTsat(Inds) = 100 * (TR_MT*(alpha_MT*(A./MTw_data(Inds)) - ones(size(MTw_data(Inds)))).*R1(Inds) - (alpha_MT^2)/2);
 
     % Weiskopf, N., Suckling, J., Williams, G., Correia, M.M., Inkster, B., Tait, R., Ooi, C., Bullmore, E.T., Lutti, A., 2013. Quantitative multi-parameter mapping of R1, PD(*), MT, and R2(*) at 3T: a multi-center validation. Front. Neurosci. 7, 95.
     MTsat = MTsat .* (1 - Alpha_B1)./(1 - Alpha_B1 * data.B1map);

--- a/src/Models_Functions/MTSATfun/MTSAT_exec.m
+++ b/src/Models_Functions/MTSATfun/MTSAT_exec.m
@@ -29,11 +29,13 @@ if isfield(data,'B1map') && ~isempty(data.B1map)
 	if any(size(data.B1map) ~= size(MTsat)), error('\nError in MTSAT_exec.m: B1 map dimension different from volume dimension.\n'); end
 
     % check if a T1 map was given in input; if not, compute it
-    R1(Inds) = 0.5.*((alpha_T1.*data.B1map(Inds)./TR_T1).*T1w_data(Inds)  - (alpha_PD*data.B1map(Inds)./TR_PD).*PDw_data(Inds))./(PDw_data(Inds)./(alpha_PD*data.B1map(Inds)) - T1w_data(Inds)./(alpha_T1*data.B1map(Inds)));
+    % B1 multiplication is factored out from each alpha for better numerical precision
+    R1(Inds) = (0.5.*data.B1map(Inds).^2).*((alpha_T1./TR_T1).*T1w_data(Inds)  - (alpha_PD./TR_PD).*PDw_data(Inds))./(PDw_data(Inds)./alpha_PD - T1w_data(Inds)./alpha_T1);
     
     % compute A
-    A = (TR_PD.*alpha_T1.*data.B1map(Inds)./(alpha_PD.*data.B1map(Inds)) - TR_T1.*alpha_PD.*data.B1map(Inds)./(alpha_T1.*data.B1map(Inds))).*((PDw_data(Inds).*T1w_data(Inds))./(TR_PD.*(alpha_T1.*data.B1map(Inds)).*T1w_data(Inds) - TR_T1.*(alpha_PD.*data.B1map(Inds)).*PDw_data(Inds)));
-	
+    % B1 multiplication is factored out from each alpha for better numerical precision
+    A = data.B1map(Inds).^(-1).*(TR_PD.*alpha_T1./alpha_PD - TR_T1.*alpha_PD./alpha_T1).*((PDw_data(Inds).*T1w_data(Inds))./(TR_PD.*alpha_T1.*T1w_data(Inds) - TR_T1.*alpha_PD.*PDw_data(Inds)));
+
     % preallocate and compute MTsat; percent units
     MTsat(Inds) = 100 * (TR_MT*(alpha_MT*(A./MTw_data(Inds)) - ones(size(MTw_data(Inds)))).*R1(Inds) - (alpha_MT^2)/2);
 


### PR DESCRIPTION
Although we were applying the "empirical" B1 correction factor to MTsat already, 

https://github.com/qMRLab/qMRLab/blob/e8c3312d2aef2c6303a3c4b52e6eaf074fdb32a5/src/Models_Functions/MTSATfun/MTSAT_exec.m#L40-L41

this is only one part of the correction needed when using B1. The flip angles in the calculations of R1, A, and MT also need to be corrected by B1 *in addition to the one above". This is also consistent with how other softwares handle B1 in MTsat, eg. hMRI:

* https://github.com/hMRI-group/hMRI-toolbox/blob/894a38be696e42a769765c313022f0bf1acafe64/hmri_calc_A.m#L41-L47
* https://github.com/hMRI-group/hMRI-toolbox/blob/894a38be696e42a769765c313022f0bf1acafe64/hmri_calc_R1.m#L41-L47

^That's for the R1 and A equations. For the MTsat equation though, they seem to to not be doing this correction prior to the empirical, which, is it a bug?

https://github.com/hMRI-group/hMRI-toolbox/blob/894a38be696e42a769765c313022f0bf1acafe64/hmri_create_MTProt.m#L684-L693

Note also their equation seems to differ from ours (in form at least, I'd need to check the factorizations/simplifications if there are any).

https://github.com/qMRLab/qMRLab/blob/e8c3312d2aef2c6303a3c4b52e6eaf074fdb32a5/src/Models_Functions/MTSATfun/MTSAT_exec.m#L34
