### PR TITLE
MP2RAGE single voxel sim & fit

### DIFF
--- a/Test/Common/sim/MP2RAGEfunc_Test.m
+++ b/Test/Common/sim/MP2RAGEfunc_Test.m
@@ -1,0 +1,28 @@
+classdef MP2RAGEfunc_Test < matlab.unittest.TestCase
+% Provisional comparison between MPRAGEfunc and the modified MP2RAGEfunc
+% Once the second replaces the first, reference results can be cached
+% and loaded from a MAT file.
+
+    properties (TestParameter)
+        T1 = {1.2, rand(100,1) + 0.5}
+        prot = struct(...
+            'default', struct('TRs', 6, 'TRf', 0.0067, 'n', [35 72], 'TI', [0.8 2.7], 'FA', [4 5]), ...
+            'madeup', struct('TRs', 5, 'TRf', 0.005, 'n', 20, 'TI', [0.7 1.5 2.4], 'FA', [3 4 7]));
+        invEff = {0.96, 0.92};
+        seq = {'normal', 'waterexcitation'};
+    end
+
+    methods (Test, ParameterCombination = 'pairwise')
+        function testProperty(testCase, T1, prot, invEff, seq)
+
+            Ni = numel(prot.TI);
+            fref = @(T1) MPRAGEfunc(Ni, prot.TRs, prot.TI, prot.n, prot.TRf, prot.FA, seq, T1, invEff);
+            Sref = arrayfun(fref, T1, 'UniformOutput', 0);
+            Sref = cat(1,Sref{:});
+
+            S = MP2RAGEfunc(prot.TRs, prot.TI, prot.n, prot.TRf, prot.FA, T1, invEff, seq);
+
+            testCase.verifyEqual(Sref, S, 'AbsTol', eps(1), 'RelTol', 1e-12)
+        end
+    end
+end

--- a/src/Addons/SingleVoxel/Sim_Single_Voxel_Curve_GUI.m
+++ b/src/Addons/SingleVoxel/Sim_Single_Voxel_Curve_GUI.m
@@ -130,8 +130,12 @@ for ii=1:length(ff)
 end
 
 % CRLB
-SNR = str2double(get(handles.options.SNR,'String'));
-[~,~,~,F] = SimCRLB(handles.Model,handles.Model.Prot.(handles.Model.MRIinputs{1}).Mat,x,1/SNR);
+if isfield(handles.Model.Prot, handles.Model.MRIinputs{1})
+    SNR = str2double(get(handles.options.SNR,'String'));
+    [~,~,~,F] = SimCRLB(handles.Model,handles.Model.Prot.(handles.Model.MRIinputs{1}).Mat,x,1/SNR);
+else
+    F = NaN(size(x));
+end
 
 for ii=1:sum(~handles.Model.fx)
     ll=find(~handles.Model.fx);

--- a/src/Common/GUI/Custom_OptionsGUI.m
+++ b/src/Common/GUI/Custom_OptionsGUI.m
@@ -143,7 +143,8 @@ Nparam = length(Model.xnames);
 
 % FitOptTable related conditional block
 
-if ~isprop(Model, 'voxelwise') || (isprop(Model, 'voxelwise') && Model.voxelwise ~= 0)
+% See #524 issue for why this condition is commented out
+% if ~isprop(Model, 'voxelwise') || (isprop(Model, 'voxelwise') && Model.voxelwise ~= 0)
 
     FitOptTable(:,1) = Model.xnames(:);
 
@@ -176,7 +177,7 @@ if ~isprop(Model, 'voxelwise') || (isprop(Model, 'voxelwise') && Model.voxelwise
         warning('Problem with adding TooltipString');
 
     end
-end
+% end
 
 % MODEL PROPERTY ADAPTIVE DYNAMIC SUBPANELS
 % ======================================================================

--- a/src/Models/T1_relaxometry/mp2rage.m
+++ b/src/Models/T1_relaxometry/mp2rage.m
@@ -44,7 +44,7 @@ end
 
 properties
     MRIinputs = {'MP2RAGE','INV1mag','INV1phase','INV2mag','INV2phase','B1map' 'Mask'};
-    xnames = {'T1','R1','MP2RAGE','MP2RAGEcor'};
+    xnames = {'T1'};
     voxelwise = 0;
 
     % Protocol
@@ -76,6 +76,23 @@ properties
     tips = {'Inv efficiency', 'Efficiency of the inversion pulse (fraction).'};
 
     options= struct(); % structure filled by the buttons. Leave empty in the code
+
+    % fitting options
+    st = [1.5];  % starting point
+    lb = [0.1];  % lower bound
+    ub = [5.0];  % upper bound
+    fx = [0];  % fix parameters
+
+    % Simulation Options
+    Sim_Single_Voxel_Curve_buttons = {'SNR', 50, 'T1', 1.5, 'Update input variables','pushbutton'};
+end
+
+methods (Static)
+    function img = signal2img(INV1, INV2)
+        img = real(INV1 .* INV2 ./ (INV1.^2 + INV2.^2)) * 4095 + 2048;
+        img(img < 0) = 0;
+        img(img > 4095) = 4095;
+    end
 end
 
 methods
@@ -84,7 +101,45 @@ methods
     
         obj.options = button2opts(obj.buttons);
         obj.onlineData_url = obj.getLink('https://osf.io/8x2c9/download?version=4','https://osf.io/k3shf/download?version=1','https://osf.io/k3shf/download?version=1');
-    
+    end
+
+    function xnew = SimOpt(obj, x, Opt)
+        xnew = [Opt.T1];
+    end
+
+    function MP2RAGE = Protocol2Params(obj)
+    % Convert protocol to the MP2RAGE source code conventions
+
+        % MP2RAGE.B0 = obj.Prot.Hardware.Mat;  % in Tesla
+
+        % RepetitionTime
+        MP2RAGE.TR = obj.Prot.RepetitionTimes.Mat(1);      % MP2RAGE TR in seconds
+        MP2RAGE.TRFLASH = obj.Prot.RepetitionTimes.Mat(2); % TR of the GRE readout
+
+        % inversion times - time between middle of refocusing pulse and excitatoin of the k-space center encoding
+        MP2RAGE.TIs = obj.Prot.Timing.Mat';
+
+        % KSpace
+        NumberShots = obj.Prot.NumberOfShots.Mat';
+        MP2RAGE.NZslices = NumberShots; % Excitations [before, after] the k-space center
+
+        % Flip angle of the two readouts in degrees
+        MP2RAGE.FlipDegrees = obj.Prot.Sequence.Mat';
+
+        % If both NumberShots are equal, then assume half/half for before/after
+        if NumberShots(1) == NumberShots(2)
+            MP2RAGE.NZslices = [ceil(NumberShots(1)/2) floor(NumberShots(1)/2)];
+        end
+    end
+
+    function Smodel = equation(obj, x)
+    % Generates an MP2RAGE signal based on protocol and fit parameters
+        x = mat2struct(x, obj.xnames);
+
+        P = obj.Protocol2Params();
+        invEFF = obj.options.Invefficiency;
+
+        Smodel = MP2RAGEfunc(P.TR, P.TIs, P.NZslices, P.TRFLASH, P.FlipDegrees, x.T1, invEFF);
     end
 
     function FitResult = fit(obj,data)
@@ -145,36 +200,7 @@ methods
 
         % LOAD PROTOCOLS =========================================
 
-        % Hardware
-        MagneticFieldStrength = obj.Prot.Hardware.Mat;
-
-        % RepetitionTime
-        RepetitionTimeInversion = obj.Prot.RepetitionTimes.Mat(1);
-        RepetitionTimeExcitation = obj.Prot.RepetitionTimes.Mat(2);
-
-        % Timing
-        InversionTime = obj.Prot.Timing.Mat';
-
-        % Sequence
-        FlipAngle = obj.Prot.Sequence.Mat';
-
-        % KSpace
-        NumberShots = obj.Prot.NumberOfShots.Mat';
-
-            % Convert naming to the MP2RAGE source code conventions
-            MP2RAGE.B0 = MagneticFieldStrength;           % in Tesla
-            MP2RAGE.TR = RepetitionTimeInversion;           % MP2RAGE TR in seconds
-            MP2RAGE.TRFLASH = RepetitionTimeExcitation; % TR of the GRE readout
-            MP2RAGE.TIs = InversionTime; % inversion times - time between middle of refocusing pulse and excitatoin of the k-space center encoding
-            MP2RAGE.NZslices = NumberShots; % Excitations [before, after] the k-space center
-            MP2RAGE.FlipDegrees = FlipAngle; % Flip angle of the two readouts in degrees
-
-            % If both NumberShots are equal, then assume half/half for before/after
-        if NumberShots(1) == NumberShots(2)
-
-            MP2RAGE.NZslices = [ceil(NumberShots(1)/2) floor(NumberShots(1)/2)]; 
-
-        end 
+        MP2RAGE = obj.Protocol2Params();
 
         % LOAD OPTIONS ========================================= 
 
@@ -187,43 +213,28 @@ methods
 
         data.INV1phase = ((data.INV1phase - min(data.INV1phase(:)))./(max(data.INV1phase(:)-min(data.INV1phase(:))))).*2.*pi;
         data.INV2phase = ((data.INV2phase - min(data.INV2phase(:)))./(max(data.INV2phase(:)-min(data.INV2phase(:))))).*2.*pi;
-       
-       end 
+
+       end
 
         if availabledata.onlyUNI || availabledata.all
-            
+
             MP2RAGEimg.img = data.MP2RAGE;
 
-        elseif availabledata.allbutUNI
+        else
+            if availabledata.allbutUNI
+                INV1 = data.INV1mag.*exp(data.INV1phase * 1j);
+                INV2 = data.INV2mag.*exp(data.INV2phase * 1j);
 
-            INV1 = data.INV1mag.*exp(data.INV1phase * 1j);
-            INV2 = data.INV2mag.*exp(data.INV2phase * 1j);
-    
+            elseif availabledata.allMagbutUNI
+                INV1 = data.INV1mag;
+                INV2 = data.INV2mag;
+            end
+
             % Combination
-            img = (real(INV1.*INV2./(INV1.^2 + INV2.^2)))*4095 + 2048; 
-            img(img<0) = 0;
-            img(img>4095) = 4095;
-            FitResult.MP2RAGE = img;
-            MP2RAGEimg.img = img;
-
-            clear('INV1','INV2','img'); 
-
-        elseif availabledata.allMagbutUNI
-
-            INV1 = data.INV1mag;
-            INV2 = data.INV2mag;
-    
-            % Combination
-            img = (INV1.*INV2./(INV1.^2 + INV2.^2))*4095 + 2048; 
-            img(img<0) = 0;
-            img(img>4095) = 4095;
-            FitResult.MP2RAGE = img;
-            MP2RAGEimg.img = img;
-
-            clear('INV1','INV2','img'); 
-            
+            MP2RAGEimg.img = mp2rage.signal2img(INV1, INV2);
+            FitResult.MP2RAGE = MP2RAGEimg.img;
         end
-        
+
         if ~isempty(data.B1map)
 
             [T1corrected, MP2RAGEcorr] = T1B1correctpackageTFL(data.B1map,MP2RAGEimg,[],MP2RAGE,[],invEFF);
@@ -253,6 +264,42 @@ methods
         end
         
     end % FIT RESULTS END 
+
+    function [FitResults, data] = Sim_Single_Voxel_Curve(obj, x, Opt, display)
+        % Simulates Single Voxel
+        %
+        % :param x: [struct] fit parameters
+        % :param Opt.SNR: [struct] signal to noise ratio to use
+        % :param display: 1=display, 0=nodisplay
+        % :returns: [struct] FitResults, data (noisy dataset)
+
+            if ~exist('display','var'), display = 0; end
+
+            Smodel = equation(obj, x);
+
+            % TODO: confirm noise distribution
+            sigma = max(abs(Smodel(:)))/Opt.SNR;
+            S = random('normal', Smodel, sigma);
+
+            data.MP2RAGE = mp2rage.signal2img(S(:, 1), S(:, 2));
+
+            FitResults = fit(obj,data);
+
+            if display
+                error('Not Implemented')
+            end
+        end
+
+        function SimVaryResults = Sim_Sensitivity_Analysis(obj, OptTable, Opt)
+            % SimVaryGUI
+            SimVaryResults = SimVary(obj, Opt.Nofrun, OptTable, Opt);
+        end
+
+        function SimRndResults = Sim_Multi_Voxel_Distribution(obj, RndParam, Opt)
+            % SimRndGUI
+            SimRndResults = SimRnd(obj, RndParam, Opt);
+        end
+
 end % METHODS END 
 
 end % CLASSDEF END 

--- a/src/Models_Functions/MP2RAGE/func/MP2RAGEfunc.m
+++ b/src/Models_Functions/MP2RAGE/func/MP2RAGEfunc.m
@@ -1,0 +1,145 @@
+function signal = MP2RAGEfunc(MPRAGE_tr, inversiontimes, nZslices, FLASH_tr, flipangle, T1s, varargin)
+% S = MP2RAGEfunc(TRs, IT, n, TRf, FA, T1, [inveff, seq, Ni]) - Simulate MP2RAGE signal
+%
+% INPUTS:
+%   TRs: [scalar] repetition time of the complete MP2RAGE sequence (ms)
+%   IT: [1 x Ni] vector of inversion times (ms), from inversion pulse to the
+%       center(*) of k-space for each image
+%   n: [scalar / 2-tuple] number of Z-slices. A tuple [n_before, n_after] shifts the
+%       "center" of k-space accordingly.
+%   TRf: [scalar] repetition time of the FLASH readout (ms)
+%   FA: [scalar or 1 x Ni] flip angle(s) of the FLASH readout (degrees)
+%   T1s: [Nv x 1] vector of T1 values to simulate (ms)
+%   inveff: [scalar] inversion efficiency (default: 0.96)
+%   seq: [string] 'normal' or 'waterexcitation' (default: 'normal')
+%   Ni: [scalar] number of images i.e. GRE imaging blocks (default: numel(IT))
+%
+% OUTPUTS:
+%   S: [Nv x Ni] simulated signal values
+%
+% See also: mp2rage, MP2RAGEfunc_Test
+
+%% Parse inputs
+varargin(end+1:3) = {[]};
+assert(numel(varargin) == 3, 'Too many arguments')
+[inveff, sequence, nimages] = deal(varargin{:});
+
+isrealscalar = @(x) isnumeric(x) && isscalar(x) && isreal(x);
+assert(isrealscalar(MPRAGE_tr) && MPRAGE_tr > 0)
+assert(isrealscalar(FLASH_tr) && FLASH_tr > 0)
+
+if isempty(nimages), nimages = numel(inversiontimes); end
+assert(isrealscalar(nimages) && nimages > 0 && mod(nimages,1) == 0)
+
+isrealntuple = @(x) isnumeric(x) && numel(x) == nimages && isreal(x);
+assert(isrealntuple(inversiontimes) && all(inversiontimes > 0) && issorted(inversiontimes))
+
+if isscalar(flipangle), flipangle = repmat(flipangle, [1, nimages]); end
+assert(isrealntuple(flipangle) && all(flipangle ~= 0))
+
+assert(isnumeric(nZslices) && isreal(nZslices))
+switch numel(nZslices)
+    case 2
+        nZ_bef = nZslices(1);
+        nZ_aft = nZslices(2);
+        nZslices = sum(nZslices);
+    case 1
+        nZ_bef = nZslices / 2;
+        nZ_aft = nZslices / 2;
+    otherwise
+        error('Expecting scalar or 2-tuple for n number of slices')
+end
+assert(mod(nZslices,1) == 0)
+
+if isempty(inveff)
+    inveff = 0.96;  % Siemens MP2RAGE PULSE
+else
+    assert(isrealscalar(inveff) && inveff > 0 && inveff <= 1)
+end
+
+if isempty(sequence), sequence = 'normal'; end
+assert(ischar(sequence));
+if strcmpi(sequence,'normal')
+    normalsequence = true;
+    waterexcitation = false;
+else
+    normalsequence = false;
+    waterexcitation = true;
+    B0 = 7;
+    FatWaterCSppm = 3.3;  % ppm
+    gamma = 42.576;  % MHz/T
+    pulseSpace = 0.5 / (FatWaterCSppm * B0 * gamma);
+end
+
+assert(isnumeric(T1s) && isvector(T1s));
+
+%% calculating the relevant timing and associated values
+
+% Reserve first dimension for voxels, second for images
+T1s = T1s(:);                        % [Nv, 1] vector
+fliprad = flipangle(:)' / 180 * pi;  % [1, Ni] vector
+
+E_1 = exp(-FLASH_tr ./ T1s);  % [Nv, 1] recovery between two excitaions
+
+TA = nZslices * FLASH_tr;
+TA_bef = nZ_bef * FLASH_tr;
+TA_aft = nZ_aft * FLASH_tr;
+
+% TD: [1, Ni + 1] vector of delay times
+TD(1) = inversiontimes(1) - TA_bef;
+TD(2:nimages) = diff(inversiontimes) - TA;
+TD(nimages+1) = MPRAGE_tr - inversiontimes(nimages) - TA_aft;
+if ~all(TD > 0)
+    error('TRs, IT, n, TRf parameters result in negative delay time(s). Please check your inputs.')
+end
+
+E_TD = exp(-TD ./ T1s);  % [Nv, Ni + 1]
+
+if normalsequence
+    cosalfaE1 = cos(fliprad) .* E_1;  % [Nv, Ni]
+    sinalfa = sin(fliprad);
+    % oneminusE1 = 1 - E_1;
+end
+if waterexcitation
+
+    E_1A = exp(-pulseSpace ./ T1s);
+    E_2A = exp(-pulseSpace ./ 0.06);  % 60 ms is an extimation of the T2star.. not very relevant
+    E_1B = exp(-(FLASH_tr - pulseSpace) ./ T1s);
+
+    cosalfaE1 = cos(fliprad/2).^2 .* (E_1A .* E_1B) - sin(fliprad/2).^2 .* (E_2A .* E_1B);
+    sinalfa = sin(fliprad/2) .* cos(fliprad/2) .* (E_1A + E_2A);
+
+    % TODO: is this meant to be used?
+    % oneminusE1 = 1 - (1 - (1 - E_1A) .* cos(fliprad/2)) .* E_1B;
+end
+
+%% steady state calculation
+
+% an expression pattern that occurs in several places
+aux = @(k, c, n) k .* c.^n + (1 - E_1) .* (1 - c.^n) ./ (1 - c);
+
+MZsteadystate = 1 ./ (1 + inveff * prod(cosalfaE1, 2).^nZslices .* prod(E_TD, 2));
+
+MZsteadystatenumerator = 1 - E_TD(:, 1);
+for k = 1:nimages
+    %term relative to the image aquisition;
+    MZsteadystatenumerator = aux(MZsteadystatenumerator, cosalfaE1(:,k), nZslices);
+
+    %term for the relaxation time after it;
+    MZsteadystatenumerator = 1 + (MZsteadystatenumerator - 1).*E_TD(:, k+1);
+end
+MZsteadystate = MZsteadystate .* MZsteadystatenumerator;
+
+%% signal
+temp = aux(1 - E_TD(:,1).*(1 + inveff * MZsteadystate), cosalfaE1(:,1), nZ_bef);
+
+signal = nan(size(temp,1), nimages);
+signal(:,1) = sinalfa(:,1) .* temp;
+
+if nimages > 1
+    for m = 2:nimages
+        temp = aux(temp, cosalfaE1(:, m-1), nZ_aft);
+        temp = aux(1 + (temp - 1) .* E_TD(:, m), cosalfaE1(:, m), nZ_bef);
+        signal(:, m) = sinalfa(:, m) .* temp;
+    end
+end

--- a/src/Models_Functions/MP2RAGE/func/MPRAGEfunc.m
+++ b/src/Models_Functions/MP2RAGE/func/MPRAGEfunc.m
@@ -68,7 +68,7 @@ if normalsequence
     end;
     for k=1:(nimages)
         cosalfaE1(k)=cos(fliprad(k))*(E_1);
-        oneminusE1(k)=1-E_1;
+        % oneminusE1(k)=1-E_1; NOT USED!
         sinalfa(k)=sin(fliprad(k));
     end;
     
@@ -86,7 +86,7 @@ if waterexcitation
     
     TD(1)=inversiontimes(1)-TA_bef;
     E_TD(1)=exp(-TD(1)./T1s);
-    TD(nimages+1)=MPRAGE_tr-inversiontimes(nimages)-T_aft;
+    TD(nimages+1)=MPRAGE_tr-inversiontimes(nimages)-TA_aft;
     E_TD(nimages+1)=exp(-TD(nimages+1)./T1s);
     
     if nimages>1
@@ -98,7 +98,7 @@ if waterexcitation
     
     for k=1:(nimages)
         cosalfaE1(k)=(cos(fliprad(k)/2)).^2*(E_1A*E_1B)-(sin(fliprad(k)/2)).^2*(E_2A*E_1B);
-        oneminusE1(k)=(1-E_1A)*cos(fliprad(k)/2)*E_1B+(1-E_1B);
+        % oneminusE1(k)=(1-E_1A)*cos(fliprad(k)/2)*E_1B+(1-E_1B); NOT USED!
         sinalfa(k)=sin( fliprad(k) / 2).*cos(fliprad(k)/2).*(E_1A+E_2A);
     end;
     


### PR DESCRIPTION
## Purpose
Feature #379

## Approach
- Gave `MPRAGEfunc` a good linting and used it for `mp2rage.equation`, in the process found a couple of issues in (what appears to be) an unused part of the code. The cleaned-up version of `MPRAGEfunc` is currently a separate function. It allows defining a parametric test that just checks against the results of the original.

- Added other functions and minimal changes to `mp2rage` to support the three types of simulations. I had to make some changes to the class parameters, most notable `xnames`. `FitResults` can still return whatever it pleases, but `xnames` is tightly coupled with the simulation logic.

- Did a little refactoring to reduce code duplication 

- Provisionally? patched `Custom_OptionsGUI` to let the simulation work without setting `voxelwise=1` (which makes fitting unusably slow) (#524)

- Provisionally? patched  `Sim_Single_Voxel_Curve_GUI` to keep the single voxel simulation from crashing when trying to call `SimCRLB`. It seems the protocol should be rearranged to contain a `Prot.MP2RAGE` field, but the implications (and importance) of this change escape me.

#### Open Questions and Pre-Merge TODOs

- [ ] Review changes (and open question) in `MPRAGEfun`
- [ ] Replace `MPRAGEfun` by cleaned-up `MP2RAGEfun`, update test to use cached results.
- [ ] Check `MPRAGEfun` against simplified equations in [docs](https://qmrlab.org/mooc/t1-mapping/#mp2rageintroduction). I figured the first was a more general version, but I'm not sure it's exactly equivalent.
- [ ] Add plotting?... there's really not much to see
- [ ] Confirm patch to resolve #524
- [ ] Confirm patch to resolve `SimCRLB` issue / rearrange protocol
- [ ] I noticed that all parameter times are in seconds (?) but _ms_ are used in other Models, is this important for consistency?
----

- [ ] Use github checklists. When solved, check the box and explain the answer.

- [ ] Review that changed source files/lines are related to the pull request/issue
_If any files/commits were accidentally included, cherry-pick them into another branch._

- [ ] Review that changed source files/lines were not accidentally deleted
_Fix appropriately if so._

- [ ] Test new features or bug fix
_If not implemented/resolved adequately, solve it or inform the developer by requesting changes in your review._
_Preferably, set breakpoints in the locations that the code was changed and follow allong line by line to see if the code behaves as intended._

##### Manual GUI tests (general)

- [ ] Does the qMRLab GUI open?
- [ ] Can you change models?
- [ ] Can you load a data folder for a model?
- [ ] Can you view data?
- [ ] Can you zoom in the image?
- [ ] Can you pan out of the image?
- [ ] Can you view the histogram of the data?
- [ ] Can you change the color map?
- [ ] Can you fit dataset (Fit data)?
- [ ] Can you save/load the results?
- [ ] Can you open the options panel?
- [ ] Can you change option parameters?
- [ ] Can you save/load option paramters?
- [ ] Can you select a voxel?
- [ ] Can you fit the data of that voxel ("View data fit")?
- [ ] Can you simulate and fit a voxel ("Single Voxel Curve")?
- [ ] Can you run a Sensitivity Analysis?
- [ ] Can you simulate a Multi Voxel Distribution?

##### Specifications

  - Version:
  - Platform:
  - Subsystem:
