### PR TITLE
535 Fix download data redirect

### DIFF
--- a/Test/Common/downloadData_Test.m
+++ b/Test/Common/downloadData_Test.m
@@ -7,6 +7,7 @@ classdef downloadData_Test < matlab.unittest.TestCase
 
     properties (TestParameter)
         method = {'auto', 'curl', 'wget', 'websave', 'request', 'urlwrite'};
+        methodRealData = {'auto', 'request'}
     end
 
     methods (TestClassSetup)
@@ -42,7 +43,7 @@ classdef downloadData_Test < matlab.unittest.TestCase
             testCase.verifyTrue(exist(file, 'file') == 2);
         end
 
-        function test_model_auto_download(testCase)
+        function test_model_demo_download(testCase, methodRealData)
             % Test the full downloadData function with a model's demo data
 
             % downloadData will cd into the demo folder. Make sure we go back.
@@ -53,7 +54,7 @@ classdef downloadData_Test < matlab.unittest.TestCase
             % Using a mock structure here to avoid dependency on the actual model.
             mdl = struct('ModelName', 'b1_dam', 'onlineData_url', 'https://osf.io/mw3sq/download?version=3');
 
-            dataPath = downloadData(mdl, testCase.path, 'auto', 3);
+            dataPath = downloadData(mdl, testCase.path, methodRealData, 3);
 
             testCase.verifyTrue(exist(dataPath,'dir') == 7, 'Failed to find data directory');
             fitResultsPath = fullfile(fileparts(dataPath),'FitResults','FitResults.mat');

--- a/Test/Common/downloadData_Test.m
+++ b/Test/Common/downloadData_Test.m
@@ -1,0 +1,73 @@
+classdef downloadData_Test < matlab.unittest.TestCase
+
+    properties
+        path = '';
+        localfunctions = struct();
+    end
+
+    properties (TestParameter)
+        method = {'auto', 'curl', 'wget', 'websave', 'request', 'urlwrite'};
+    end
+
+    methods (TestClassSetup)
+        function setupMethods(testCase)
+            % This is a backdoor to access the local functions for unit testing:
+            % https://uk.mathworks.com/matlabcentral/answers/1915540-can-i-access-local-functions-for-unit-testing
+            testCase.localfunctions = downloadData('localfunctions');
+        end
+        function makeTestDir(testCase)
+            testCase.path = fullfile(tempdir(), 'downloadData_Test');
+            mkdir(testCase.path);
+        end
+    end
+
+    methods (TestClassTeardown)
+        function removeTestDir(testCase)
+            rmdir(testCase.path, 's');
+        end
+    end
+
+    methods(Test)
+        function test_method(testCase, method)
+            % Download a plain HTML file using each method
+
+            % skip wget/curl if commands are not available on the system
+            if ismember(method, {'wget', 'curl'})
+                testCase.assumeTrue(system([method, ' --version']) == 0);
+            end
+
+            downladFunction = testCase.localfunctions.(method);
+            file = fullfile(testCase.path, [method '_test.html']);
+            downladFunction('http://example.com', file, 30);
+            testCase.verifyTrue(exist(file, 'file') == 2);
+        end
+
+        function test_model_auto_download(testCase)
+            % Test the full downloadData function with a model's demo data
+
+            % downloadData will cd into the demo folder. Make sure we go back.
+            here = pwd();
+            goBack = onCleanup(@() cd(here));
+
+            % b1_dam has the smallest demo dataset.
+            % Using a mock structure here to avoid dependency on the actual model.
+            mdl = struct('ModelName', 'b1_dam', 'onlineData_url', 'https://osf.io/mw3sq/download?version=3');
+
+            dataPath = downloadData(mdl, testCase.path, 'auto', 3);
+
+            testCase.verifyTrue(exist(dataPath,'dir') == 7, 'Failed to find data directory');
+            fitResultsPath = fullfile(fileparts(dataPath),'FitResults','FitResults.mat');
+            testCase.verifyTrue(exist(fitResultsPath,'file') == 2, 'Failed to find unzipped FitResults.mat file');
+        end
+
+        function test_model_bad_download(testCase)
+            % Test a mock model with an invalid URL
+
+            here = pwd();
+            goBack = onCleanup(@() cd(here));
+
+            mdl = struct('ModelName', 'mock', 'onlineData_url', 'http://badurl');
+            testCase.verifyError(@() downloadData(mdl, testCase.path, 'auto', 1, 3), 'qMRLab:download:fail');
+        end
+    end
+end

--- a/Test/Common/downloadData_Test.m
+++ b/Test/Common/downloadData_Test.m
@@ -37,9 +37,9 @@ classdef downloadData_Test < matlab.unittest.TestCase
                 testCase.assumeTrue(system([method, ' --version']) == 0);
             end
 
-            downladFunction = testCase.localfunctions.(method);
+            downloadFunction = testCase.localfunctions.(method);
             file = fullfile(testCase.path, [method '_test.html']);
-            downladFunction('http://example.com', file, 30);
+            downlooadFunction('http://example.com', file, 30);
             testCase.verifyTrue(exist(file, 'file') == 2);
         end
 

--- a/Test/Common/downloadData_Test.m
+++ b/Test/Common/downloadData_Test.m
@@ -39,7 +39,7 @@ classdef downloadData_Test < matlab.unittest.TestCase
 
             downloadFunction = testCase.localfunctions.(method);
             file = fullfile(testCase.path, [method '_test.html']);
-            downlooadFunction('http://example.com', file, 30);
+            downloadFunction('http://example.com', file, 30);
             testCase.verifyTrue(exist(file, 'file') == 2);
         end
 

--- a/src/Common/downloadData.m
+++ b/src/Common/downloadData.m
@@ -1,21 +1,78 @@
-function dataPath = downloadData(Model,path)
+function dataPath = downloadData(Model, path, method, attempts, timeout)
 % Downlaod example data for a given qMRLab model
+%
+%   DATAPATH = downloadData(MODEL, PATH)
+%   DATAPATH = downloadData(MODEL, PATH, METHOD, ATTEMPTS, TIMEOUT)
+%
+% The function will create a 'PATH/NAME_demo' folder(where NAME is the model name),
+% cd into it, download data from the URL specified in MODEL.onlineData_url,
+% and unzip it into a structure:
+%
+%   PATH/NAME_demo:
+%   ├─ NAME_data
+%   |   ├─ [*.zip original download]
+%   |   └─ [*.nii.gz model input maps]
+%   └─ FitResults
+%       ├─ FitResults.mat
+%       └─ [*.nii.gz model output maps]
+%
+% Inputs:
+%   MODEL: A qMRLab model object (e.g. T1map, MWF, etc.)
+%   PATH: (optional) A directory where the data should be downloaded.
+%       If not provided, a dialog will prompt the user to select a directory.
+%   METHOD: (optional) One of {'auto', 'curl', 'wget', 'websave', 'request', 'urlwrite'},
+%       the default 'auto' will try all other methods in order.
+%   ATTEMPTS: (optional) max download attempts, defaults to 5.
+%   TIMEOUT: (optional) connection timeout in seconds, defaults to 60.
+%
+% Output:
+%   DATAPATH: The path to the downloaded data folder: ./NAME_data
+
+METHODS = struct(...
+    'auto', @downloadAuto, ...
+    'curl', @downloadWithCurl, ...
+    'wget', @downloadWithWget, ...
+    'websave', @downloadWithWebsave, ...
+    'request', @downloadWithRedirects, ...
+    'urlwrite', @downloadWithUrlwrite ...
+);
+
+% Unit-testing backdoor, see Test/Common/downloadData_Test.m
+if nargin == 1 && isequal(Model, 'localfunctions')
+    dataPath = METHODS;
+    return;
+end
 
 if ~exist('path','var') || isempty(path)
-h = msgbox('Please select a destination to create example folder.','qMRLab');
-waitfor(h);
-path = uigetdir(); % Save batch example to this dir
+    h = msgbox('Please select a destination to create example folder.','qMRLab');
+    waitfor(h);
+    path = uigetdir(); % Save batch example to this dir
 end
 if ~path, dataPath = []; return; end
+
+if ~exist('method','var') || isempty(method)
+    method = 'auto';
+end
+
+if ~exist('attempts','var') || isempty(attempts)
+    attempts = 5;
+end
+
+if ~exist('timeout', 'var') || isempty(timeout)
+    timeout = 60;
+end
+
+method = lower(method);
+if ~ismember(method, fieldnames(METHODS))
+    error('qMRLab:download:method', 'Invalid method. Choose from: %s', strjoin(fieldnames(METHODS), ', '));
+end
+
 cd(path);
 path = '.'; % use relative path
 
 mkdir([Model.ModelName '_demo']);
 cd([Model.ModelName '_demo']);
-% if not(moxunit_util_platform_is_octave)
-% commandwindow; %% remove this line--> not compatible with GUI usage
-% end
-disp('Please wait. Downloading data ...');
+
 try
     url = Model.onlineData_url;
 catch
@@ -25,108 +82,32 @@ catch
 end
 filename = [Model.ModelName '.zip'];
 
-err_count = 0;
-max_attempts = 5;
-download_successful = false;
-while err_count < max_attempts && ~download_successful
+disp('Please wait. Downloading data ...');
+for err_count = 1:attempts
     try
         % DOWNLOAD
-        if moxunit_util_platform_is_octave
-            if isunix && ~isempty(getenv('ISCITEST')) && str2double(getenv('ISCITEST')) % issue #113 --> no outputs on TRAVIS
-                cmd = ['curl -L -o ' filename ' ' url];
-                disp(cmd)
-                [STATUS,MESSAGE] = unix(cmd);
-                if STATUS, error(MESSAGE); end
-            else
-                [~, SUCCESS, MESSAGE] = urlwrite(url,filename);
-                if ~SUCCESS, error(MESSAGE); end
-            end
-        else
-            % Try multiple methods to handle OSF redirects (308 status)
-            download_success = false;
-
-            % Method 1: Try system curl (most reliable for redirects)
-            if isunix || ismac
-                try
-                    cmd = ['curl -L -o ' filename ' "' url '"'];
-                    [STATUS, ~] = system(cmd);
-                    if STATUS == 0 && exist(filename, 'file')
-                        download_success = true;
-                        disp('Data has been downloaded using curl...');
-                    end
-                catch
-                    % curl failed, try next method
-                end
-            end
-
-            % Method 2: Try wget if curl failed
-            if ~download_success && (isunix || ismac)
-                try
-                    cmd = ['wget -O ' filename ' "' url '"'];
-                    [STATUS, ~] = system(cmd);
-                    if STATUS == 0 && exist(filename, 'file')
-                        download_success = true;
-                        disp('Data has been downloaded using wget...');
-                    end
-                catch
-                    % wget failed, try next method
-                end
-            end
-
-            % Method 3: Try MATLAB websave with options
-            if ~download_success
-                try
-                    options = weboptions('Timeout', 60, ...
-                                        'ContentType', 'binary', ...
-                                        'CertificateFilename', '');
-                    websave(filename, url, options);
-                    download_success = true;
-                    disp('Data has been downloaded ...');
-                catch
-                    % websave failed, try next method
-                end
-            end
-
-            % Method 4: Try custom redirect handler
-            if ~download_success
-                try
-                    downloadWithRedirects(url, filename);
-                    download_success = true;
-                catch
-                    % custom redirect handler failed, try final method
-                end
-            end
-
-            % Method 5: Try urlwrite (older but sometimes works better)
-            if ~download_success
-                try
-                    urlwrite(url, filename); %#ok<URLWR>
-                    disp('Data has been downloaded ...');
-                catch ME_final
-                    % All methods failed
-                    error(['Could not download using any method: ' ME_final.message]);
-                end
-            end
-        end
+        METHODS.(method)(url, filename, timeout);
+        disp('Download successful. Unzipping data ...');
 
         % UNZIP
         unzip(filename);
-        download_successful = true;
+        break
     catch ME
-        err_count = err_count + 1;
         disp(['Download attempt ' num2str(err_count) ' failed.']);
-        if err_count >= max_attempts
-            error(['Data cannot be downloaded after ' num2str(max_attempts) ' attempts: ' ME.message ...
+        if err_count >= attempts
+            error('qMRLab:download:fail', ...
+                ['Data cannot be downloaded after ' num2str(attempts) ' attempts: ' ME.message ...
                 '\n\nTroubleshooting tips:' ...
                 '\n- Check your internet connection' ...
                 '\n- The OSF server may be temporarily unavailable' ...
                 '\n- Try downloading manually from: ' url ...
                 '\n- Check if a firewall is blocking the connection']);
         end
-        % Wait before retry
-        disp('Retrying...');
-        pause(2);
     end
+
+    % Wait before retry
+    disp('Retrying...');
+    pause(2);
 end
 
 oldname = [path filesep filename(1:end-4)];
@@ -150,12 +131,107 @@ end
 
 end
 
-function downloadWithRedirects(url, outputFile, maxRedirects)
+function downloadAuto(url, filename, timeout)
+% Try multiple methods to handle OSF redirects (308 status)
+
+    if moxunit_util_platform_is_octave
+        if isunix && ~isempty(getenv('ISCITEST')) && str2double(getenv('ISCITEST')) % issue #113 --> no outputs on TRAVIS
+            downloadWithCurl(url, filename, timeout)
+        else
+            downloadWithUrlwrite(url, filename, timeout)
+        end
+    else
+        % Method 1: Try system curl (most reliable for redirects)
+        if isunix || ismac
+            try
+                downloadWithCurl(url, filename, timeout)
+                return;
+            catch
+                % curl failed, try next method
+            end
+        end
+
+        % Method 2: Try wget if curl failed
+        if isunix || ismac
+            try
+                downloadWithWget(url, filename, timeout)
+                return;
+            catch
+                % wget failed, try next method
+            end
+        end
+
+        % Method 3: Try MATLAB websave with options
+        try
+            downloadWithWebsave(url, filename, timeout)
+            return;
+        catch
+            % websave failed, try next method
+        end
+
+        % Method 4: Try custom redirect handler
+        try
+            downloadWithRedirects(url, filename, timeout);
+            return;
+        catch
+            % custom redirect handler failed, try final method
+        end
+
+        % Method 5: Try urlwrite (older but sometimes works better)
+        try
+            downloadWithUrlwrite(url, filename, timeout);
+        catch ME_final
+            % All methods failed
+            error(['Could not download using any method: ' ME_final.message]);
+        end
+    end
+end
+
+function downloadWithCurl(url, filename, timeout)
+% Download using system curl (most reliable for redirects)
+
+    cmd = sprintf('curl -L --connect-timeout %d -o "%s" "%s"', timeout, filename, url);
+    [STATUS, MESSAGE] = system(cmd);
+    if STATUS == 0 && exist(filename, 'file')
+        disp('Data has been downloaded using curl...');
+    end
+    if STATUS, error(MESSAGE); end
+end
+
+function downloadWithWget(url, filename, timeout)
+% Download using system wget (alternative for redirects)
+
+    cmd = sprintf('wget --timeout=%d -O "%s" "%s"', timeout, filename, url);
+    [STATUS, MESSAGE] = system(cmd);
+    if STATUS == 0 && exist(filename, 'file')
+        disp('Data has been downloaded using wget...');
+    end
+    if STATUS, error(MESSAGE); end
+end
+
+function downloadWithWebsave(url, filename, timeout)
+% Download using MATLAB websave with options
+
+    options = weboptions('Timeout', timeout, ...
+                        'ContentType', 'binary', ...
+                        'CertificateFilename', '');
+    websave(filename, url, options);
+    disp('Data has been downloaded using websave...');
+end
+
+function downloadWithUrlwrite(url, filename, timeout)
+% Download using urlwrite (older but sometimes works better)
+
+    urlwrite(url, filename, 'Timeout', timeout); %#ok<URLWR>
+    disp('Data has been downloaded ...');
+end
+
+function downloadWithRedirects(url, outputFile, timeout, maxRedirects)
 % Download a file following HTTP redirects manually
 %   WEBSAVE struggles with the chain 301 -> 308 -> 302 required
 %   for some OSF paths.
 
-    if nargin < 3
+    if nargin < 4
         maxRedirects = 10;
     end
 
@@ -165,7 +241,7 @@ function downloadWithRedirects(url, outputFile, maxRedirects)
     while redirectCount < maxRedirects
         request = matlab.net.http.RequestMessage('GET');
         uri = matlab.net.URI(currentUrl);
-        options = matlab.net.http.HTTPOptions('ConnectTimeout', 60);
+        options = matlab.net.http.HTTPOptions('ConnectTimeout', timeout);
 
         try
             response = send(request, uri, options);

--- a/src/Common/downloadData.m
+++ b/src/Common/downloadData.m
@@ -1,5 +1,5 @@
 function dataPath = downloadData(Model, path, method, attempts, timeout)
-% Downlaod example data for a given qMRLab model
+% Download example data for a given qMRLab model
 %
 %   DATAPATH = downloadData(MODEL, PATH)
 %   DATAPATH = downloadData(MODEL, PATH, METHOD, ATTEMPTS, TIMEOUT)

--- a/src/Common/downloadData.m
+++ b/src/Common/downloadData.m
@@ -192,10 +192,9 @@ function downloadWithCurl(url, filename, timeout)
 
     cmd = sprintf('curl -L --connect-timeout %d -o "%s" "%s"', timeout, filename, url);
     [STATUS, MESSAGE] = system(cmd);
-    if STATUS == 0 && exist(filename, 'file')
-        disp('Data has been downloaded using curl...');
+    if STATUS ~= 0 || ~exist(filename, 'file')
+        error('qMRLab:download:curl', '%s', MESSAGE);
     end
-    if STATUS, error(MESSAGE); end
 end
 
 function downloadWithWget(url, filename, timeout)
@@ -203,10 +202,9 @@ function downloadWithWget(url, filename, timeout)
 
     cmd = sprintf('wget --timeout=%d -O "%s" "%s"', timeout, filename, url);
     [STATUS, MESSAGE] = system(cmd);
-    if STATUS == 0 && exist(filename, 'file')
-        disp('Data has been downloaded using wget...');
+    if STATUS ~= 0 || ~exist(filename, 'file')
+        error('qMRLab:download:curl', '%s', MESSAGE);
     end
-    if STATUS, error(MESSAGE); end
 end
 
 function downloadWithWebsave(url, filename, timeout)

--- a/src/Common/downloadData.m
+++ b/src/Common/downloadData.m
@@ -103,11 +103,11 @@ for err_count = 1:attempts
                 '\n- Try downloading manually from: ' url ...
                 '\n- Check if a firewall is blocking the connection']);
         end
+        % Wait before retry
+        disp('Retrying...');
+        pause(2);
     end
 
-    % Wait before retry
-    disp('Retrying...');
-    pause(2);
 end
 
 oldname = [path filesep filename(1:end-4)];

--- a/src/Common/downloadData.m
+++ b/src/Common/downloadData.m
@@ -182,7 +182,7 @@ function downloadAuto(url, filename, timeout)
             downloadWithUrlwrite(url, filename, timeout);
         catch ME_final
             % All methods failed
-            error(['Could not download using any method: ' ME_final.message]);
+            error('qMRLab:download:auto', 'Could not download using any method: %s', ME_final.message);
         end
     end
 end

--- a/src/Common/downloadData.m
+++ b/src/Common/downloadData.m
@@ -270,9 +270,10 @@ function downloadWithRedirects(url, outputFile, timeout, maxRedirects)
                 error('Redirect response without Location header');
             end
 
+            previousUrl = currentUrl;
             currentUrl = string(locationHeader.Value);
             redirectCount = redirectCount + 1;
-            fprintf('Redirect: %s -> %s\n', url, currentUrl);
+            fprintf('Redirect: %s -> %s\n', previousUrl, currentUrl);
 
         else
             error('Unexpected status code: %d', statusCode);


### PR DESCRIPTION
## Purpose

#535: Matlab's `websave` seems to struggle with the redirect chain 301 → 308 → 302 required for some OSF paths (e.g. _mp2rage_). So the same link that works on UNIX (with `curl -L`) currently fails on Windows.

(local-branch version of #528) 

## Approach
Added a fifth download option to `downloadData` that sends repeated `matlab.net.http` requests and tries to follow the response "Location" header.

I've then refactored the whole function so that it can be unit-tested, and added tests for all methods.

#### Open Questions and Pre-Merge TODOs
- [x] Use github checklists. When solved, check the box and explain the answer.

- [x] Review that changed source files/lines are related to the pull request/issue
_If any files/commits were accidentally included, cherry-pick them into another branch._

- [x] Review that changed source files/lines were not accidentally deleted
_Fix appropriately if so._

- [x] Test new features or bug fix
_If not implemented/resolved adequately, solve it or inform the developer by requesting changes in your review._
_Preferably, set breakpoints in the locations that the code was changed and follow allong line by line to see if the code behaves as intended._

##### Manual GUI tests (general)

- [x] Does the qMRLab GUI open?
- [x] Can you change models?
- [x] Can you load a data folder for a model?
- [x] Can you view data?
- [x] Can you zoom in the image?
- [x] Can you pan out of the image?
- [x] Can you view the histogram of the data?
- [x] Can you change the color map?
- [x] Can you fit dataset (Fit data)?
- [ ] Can you save/load the results?
- [x] Can you open the options panel?
- [x] Can you change option parameters?
- [ ] Can you save/load option paramters?
- [ ] Can you select a voxel?
- [ ] Can you fit the data of that voxel ("View data fit")?
- [ ] Can you simulate and fit a voxel ("Single Voxel Curve")?
- [ ] Can you run a Sensitivity Analysis?
- [ ] Can you simulate a Multi Voxel Distribution?

##### Specifications

  - Version:
  - Platform:
  - Subsystem:
