### PR TITLE
CI/test: fix cryptic error messages in BatchExample_test

### DIFF
--- a/Test/MoxUnitCompatible/BatchExample_test.m
+++ b/Test/MoxUnitCompatible/BatchExample_test.m
@@ -29,37 +29,34 @@ for iModel = 1:length(Modellist)
     disp(['Testing: ' Modellist{iModel} ' BATCH...'])
     disp('===============================================================')
     
-    
-    eval(['Model = ' Modellist{iModel}]);
-    
-    
-    
-    
-    
-    
-    
-    qMRgenBatch(Model,pwd)
-    
-    
-    
-    
-    % Test if any dataset exist
-    isdata = true;
     try
-        Model.onlineData_url;
-    catch
-        isdata = false;
+        eval(['Model = ' Modellist{iModel}]);
+        
+        qMRgenBatch(Model,pwd)
+        
+        % Test if any dataset exist
+        isdata = true;
+        try
+            Model.onlineData_url;
+        catch
+            isdata = false;
+        end
+        
+        % Run Batch
+        if isdata
+            starttime = tic;
+            eval([Modellist{iModel} '_batch']);
+            toc(starttime)
+        end
+    catch ME
+        fprintf(2, 'Error in %s BATCH!\n', Modellist{iModel});
+        close all
+        cd(curdir)
+        rethrow(ME)
     end
-    
-    % Run Batch
-    if isdata
-        starttime = tic;
-        eval([Modellist{iModel} '_batch']);
-        toc(starttime)
-    end
+
     close all
-    cd ..
-    
+    cd(tmpDir)
 end
 cd(curdir)
 


### PR DESCRIPTION
`qMRgenBatch`  calls during `Test/MoxUnitCompatible/BatchExample_test.m` change the working directory (and don't change it back on error), causing MoxUnit to issue completely unrelated (and perfectly useless) test fail errors, e.g. https://github.com/qMRLab/qMRLab/actions/runs/25912378416/job/76160493078

Wrapping the test calls on a try-catch block and making sure to `cd` back seem to fix it.