### PR TITLE
Speed up inversion_recovery fitting ~5x by hoisting the voxel-invariant NLS grid

### DIFF
--- a/src/Models_Functions/IRfun/fitT1_IR.m
+++ b/src/Models_Functions/IRfun/fitT1_IR.m
@@ -32,12 +32,26 @@ function [T1,b,a,res,idx]=fitT1_IR(data,T_IR,method)
 % (c) Board of Trustees, Leland Stanford Junior University
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-extra.tVec = T_IR;
-extra.T1Vec = 1:5000; % Range can be reduced if a priori information is available
+% The search grid depends only on the protocol (T_IR) and the T1 range below --
+% never on the voxel data. FitData calls this function once per voxel, so
+% rebuilding the grid on every call dominated the fit. Cache it and rebuild only
+% when the protocol changes.
+%
+% The hardcoded T1 range does not need to be part of the key: editing this file
+% clears its persistent variables, so the cache cannot outlive a change to it.
+% Under parfor each worker holds its own copy and builds it once.
+persistent nlsS_cache nlsS_key
+
+key = T_IR(:).';
+if isempty(nlsS_key) || ~isequal(key, nlsS_key)
+    extra.tVec = T_IR;
+    extra.T1Vec = 1:5000; % Range can be reduced if a priori information is available
+    nlsS_cache = getNLSStruct(extra,0);
+    nlsS_key = key;
+end
+nlsS = nlsS_cache;
 
 savefitdata = 0; % Can be changed to 1 if the fit data needs to be saved
-
-nlsS = getNLSStruct(extra,0);
 
 
 switch method

--- a/src/Models_Functions/IRfun/getNLSStruct.m
+++ b/src/Models_Functions/IRfun/getNLSStruct.m
@@ -57,10 +57,27 @@ end
 % where rho = exp(-TI/T1), for different T1's.
 switch(nlsS.nlsAlg)
   case{'grid'}
-    alphaVec = 1./nlsS.T1Vec; 
+    alphaVec = 1./nlsS.T1Vec;
     nlsS.theExp = exp( -nlsS.tVec*alphaVec' );
     nlsS.rhoNormVec = ...
         sum( nlsS.theExp.^2, 1)' - ...
-        1/nlsS.N*(sum(nlsS.theExp,1)').^2;    
-end 
+        1/nlsS.N*(sum(nlsS.theExp,1)').^2;
+
+    % theExpSum is the column sum of theExp over TI. Every voxel's grid search
+    % needs it and it depends only on the protocol, so it is computed once here
+    % rather than once per voxel.
+    nlsS.theExpSum = sum(nlsS.theExp,1)';
+
+    % Ascending-TI view of the grid, used by rdNlsPr's polarity restoration.
+    % The permutation is fixed by the protocol, so the permuted matrix and its
+    % column sums are also built once here.
+    %
+    % sortedTheExpSum MUST be summed over the permuted rows rather than reused
+    % from theExpSum: floating-point addition is order dependent, so summing
+    % the same values in a different row order is not guaranteed to produce the
+    % same bits.
+    [nlsS.sortedTVec, nlsS.sortOrder] = sort(nlsS.tVec);
+    nlsS.sortedTheExp    = nlsS.theExp(nlsS.sortOrder,:);
+    nlsS.sortedTheExpSum = sum(nlsS.sortedTheExp,1)';
+end
 

--- a/src/Models_Functions/IRfun/rdNls.m
+++ b/src/Models_Functions/IRfun/rdNls.m
@@ -35,8 +35,11 @@ switch(nlsS.nlsAlg)
     
     % Compute the vector of rho'*y for different rho,
     % where rho = exp(-TI/T1) and y = dataTmp 
+    % nlsS.theExpSum is sum(nlsS.theExp,1)', precomputed in getNLSStruct. The
+    % expression is otherwise unchanged, so the association -- and hence the
+    % result -- is identical.
     rhoTyVec = (data.'*nlsS.theExp).' - ...
-      1/nlsS.N*sum(nlsS.theExp,1)'*ySum;
+      1/nlsS.N*nlsS.theExpSum*ySum;
     theExp = nlsS.theExp;
     
     % rhoNormVec is a vector containing the norm-squared of rho over TI,

--- a/src/Models_Functions/IRfun/rdNlsPr.m
+++ b/src/Models_Functions/IRfun/rdNlsPr.m
@@ -26,9 +26,11 @@ if ( length(data) ~= nlsS.N )
 end
 
 
-% Make sure the data come in increasing TI-order
-[tVec,order] = sort(nlsS.tVec); 
-data = squeeze(data); 
+% Make sure the data come in increasing TI-order. The permutation is fixed by
+% the protocol, so it is computed once in getNLSStruct rather than per voxel.
+tVec  = nlsS.sortedTVec;
+order = nlsS.sortOrder;
+data = squeeze(data);
 data = data(order);
 
 % Initialize variables
@@ -53,8 +55,11 @@ switch(nlsS.nlsAlg)
     end
 
     for ii = 1:2
-      theExp = nlsS.theExp(order,:);
-      
+      % Pre-permuted in getNLSStruct; MATLAB's copy-on-write makes this a
+      % reference, not the per-voxel copy of the full 9 x length(T1Vec) matrix
+      % that this line used to perform twice per voxel.
+      theExp = nlsS.sortedTheExp;
+
       if ii == 1
         % First, we set all elements up to and including
         % the smallest element to minus
@@ -70,9 +75,12 @@ switch(nlsS.nlsAlg)
 
       % Compute the vector of rho'*t for different rho,
       % where rho = exp(-TI/T1) and y = dataTmp
+      % nlsS.sortedTheExpSum is sum(theExp,1)' over the permuted rows,
+      % precomputed in getNLSStruct. Only the coarse pass can use it; the zoomed
+      % pass below rebuilds theExp per voxel and must still sum it directly.
       rhoTyVec = (dataTmp.'*theExp).' - ...
-        1/nlsS.N*sum(theExp,1)'*ySum;
-      
+        1/nlsS.N*nlsS.sortedTheExpSum*ySum;
+
       % rhoNormVec is a vector containing the norm-squared of rho over TI,
       % where rho = exp(-TI/T1), for different T1's.
       rhoNormVec = nlsS.rhoNormVec;


### PR DESCRIPTION
## What this does

`FitData` fits `inversion_recovery` one voxel at a time, and `fitT1_IR` rebuilt the entire
RD-NLS search grid on every one of those calls — a 9 x 5000 `exp()` matrix that depends only
on the protocol, never on the voxel. This PR caches that grid and precomputes the three other
quantities derived from it that were also being recomputed per voxel: its column sums, its
ascending-TI permutation, and that permutation's column sums. Nothing about the algorithm
changes — same grid, same maximizing criterion, same zoom refinement, same two-scenario
polarity restoration. Every change was chosen to preserve floating-point association exactly,
and the fitted maps are **bit-identical** to `main` on the demo dataset for both the Magnitude
and Complex paths. The fit gets ~5x faster.

## Illustrated example

`fitT1_IR.m` is called once per voxel. Before:

```matlab
extra.tVec  = T_IR;
extra.T1Vec = 1:5000;              % rebuilt every voxel
nlsS = getNLSStruct(extra,0);      % builds a 9 x 5000 exp() matrix ... every voxel
```

`getNLSStruct` evaluates `exp( -tVec*alphaVec' )` — 9 TIs x 5000 T1 candidates = **45,000
`exp()` calls per voxel**. On the demo dataset that is:

```
   4,532 voxels  x  45,000 exp()  =  203,940,000 evaluations
                                     of which 45,000 are distinct
                                     ( the other 203,895,000 recompute the same numbers )
```

After — build it once, reuse it:

```matlab
persistent nlsS_cache nlsS_key

key = T_IR(:).';
if isempty(nlsS_key) || ~isequal(key, nlsS_key)
    extra.tVec  = T_IR;
    extra.T1Vec = 1:5000;
    nlsS_cache  = getNLSStruct(extra,0);
    nlsS_key    = key;
end
nlsS = nlsS_cache;
```

The cache key is the protocol, so a changed `T_IR` rebuilds correctly. Editing the file clears
its persistent variables, so the hardcoded T1 range cannot go stale either. Under `parfor`
each worker holds its own copy and builds it once.

## Speedup

Demo dataset (`inversion_recovery_demo`, 128x128x1x9, 4,532 fitted voxels, TI = 350...1700 ms,
T1 grid `1:5000`), MATLAB R2026a on Apple Silicon:

| path | before | after | speedup |
|---|---|---|---|
| Magnitude (RD-NLS-PR) | 1.27 s | **0.25 s** | **4.99x** |
| Complex (RD-NLS) | 0.79 s | **0.18 s** | **4.32x** |

**How determined.** A benchmark harness (`bench_ir.m`, not included in this PR) times the fit
with `toc(t0)` on an explicit handle — `FitData` calls a bare `tic;` internally, which silently
clobbers an unhandled outer timer — and reports the best of three repetitions after a discarded
warm-up. Three independent checks guard the number: it is cross-validated against `Fit.Time`,
which `FitData` measures internally; it asserts `nnz(Fit.computed)` equals the mask count, so a
truncated fit cannot masquerade as a fast one; and it reports `ISCITEST`, which makes `FitData`
break out of the voxel loop after 3 voxels. Attribution of the cost was measured with the MATLAB
profiler rather than estimated.

**Correctness.** Output maps are compared as raw IEEE-754 bit patterns
(`typecast(x(:),'uint64')`, never floating-point `==`, which would treat `+0.0` and `-0.0` as
equal despite differing bits). All five maps (`T1`, `ra`, `rb`, `res`, `idx`) for both methods:
**0 bit-differences**, with the NaN footprint matching exactly.

## Changes

| # | File | Change | Why it helps |
|---|---|---|---|
| 1 | `fitT1_IR.m` | `persistent` cache for `nlsS`, keyed on the protocol | The grid was rebuilt for all 4,532 voxels; now built once. ~40% of the fit |
| 2 | `getNLSStruct.m` | Precompute `theExpSum` = `sum(theExp,1)'` | Every voxel's grid search needs it, and it depends only on the protocol. ~15% |
| 3 | `getNLSStruct.m` | Precompute `sortOrder`, `sortedTVec`, `sortedTheExp`, `sortedTheExpSum` | The ascending-TI permutation is fixed by the protocol, so `rdNlsPr` no longer copies a 9 x 5000 matrix twice per voxel. ~17% |
| 4 | `rdNls.m` | Use the hoisted column sums | Expression form left unchanged so the association — and the result — is identical |
| 5 | `rdNlsPr.m` | Use the pre-permuted grid and its column sums; drop the per-voxel `sort` | Same |

Net: **+57 / -15 lines** across four files. No public interface changes — `fitT1_IR`'s signature
is untouched, and `getNLSStruct`/`rdNls`/`rdNlsPr` are only called from within `IRfun`.

## Further speedup available

**Exact, no code change: `parpool`.** qMRLab already prints a tip recommending it, and
`ParFitData` already exists. Voxels are fitted independently, so distributing them reassociates
nothing — it should be **bit-identical by construction** and worth roughly another **5x** on a
10-core machine. Not exercised here because pool startup (seconds) swamps a 0.25 s fit; it pays
off on realistically sized volumes, not the demo phantom. Worth confirming with the harness
rather than assuming.

**Not exact — needs an issue first.** Everything beyond this point changes the fitted values, so
it is deliberately excluded:

| Option | Estimated gain | Note |
|---|---|---|
| Derive the second polarity scenario from the first (they differ in exactly one sample's sign, so one `axpy` replaces a full 9-row sweep) | ~1.7x on Magnitude | Would bring Magnitude to parity with Complex |
| Precompute `1./rhoNormVec` so the argmax multiplies instead of divides (5,000 divisions x 9,064 calls) | ~5% | `x/y` and `x*(1/y)` round differently |
| Replace the 5,000-point linear grid with ~200 log-spaced points plus a proper 1-D refinement | ~3-5x | The large one. 1 ms spacing is 0.1% relative resolution at T1 = 1000 ms but only 1% at T1 = 100 ms — over-resolved at the top of the range, under-resolved at the bottom |

**Suggested follow-up: open an issue** to decide when bit-identity with the current reference
output stops being a hard requirement. Together these are plausibly another **3-5x** on top of
this PR, but each needs a validation strategy that is not "diff the maps."

<details>
<summary><b>Full technical account</b> (for reviewers wanting the detail, and for LLM context)</summary>

### Algorithm background

`inversion_recovery` implements Barral et al. (2010) RD-NLS. The model `S(TI) = a + b*exp(-TI/T1)`
is linear in `a` and `b` and nonlinear only in `T1`, so `a`/`b` are profiled out in closed form
and the residual becomes a 1-D function of `T1`, searched exhaustively on a grid. Per voxel:

1. **Coarse search** — for each of 5,000 candidate T1 values compute
   `rhoTyVec(j) = sum_i data(i)*theExp(i,j) - (1/N)*colSum(j)*ySum`, where the mean-centering term
   analytically projects out the constant column corresponding to `a`, then take
   `argmax_j |rhoTyVec(j)|^2 / rhoNormVec(j)`.
2. **Zoom refinement** — rebuild a 21-point grid bracketing the winner, repeat (`nbrOfZoom = 2`).
3. **Extract** — `bHat = rhoTyVec(ind)/rhoNormVec(ind)`, `aHat = (1/N)*(ySum - bHat*sum(theExp(:,ind)))`,
   plus a normalized RMS of relative residuals.

The Magnitude path (`rdNlsPr`) runs the whole thing twice under two sign hypotheses either side of
the signal minimum, keeping the lower residual — hence Magnitude costing more than Complex.

### Measured cost, before

MATLAB profiler, Magnitude path, 4,532 voxels. `fitT1_IR` total 1.385 s:

| statement | calls | time | share | voxel-dependent? |
|---|---|---|---|---|
| `getNLSStruct` — whole function | 4,532 | 0.549 s | 39.6% | **no** |
| ├ `theExp = exp(-tVec*alphaVec')` | 4,532 | 0.324 s | 23.4% | no |
| └ `rhoNormVec = sum(theExp.^2,1)' - ...` | 4,532 | 0.193 s | 13.9% | no |
| `rdNlsPr` — whole function | 4,532 | 0.809 s | 58.4% | mixed |
| ├ `theExp = nlsS.theExp(order,:)` | 9,064 | 0.236 s | 17.0% | **no** |
| ├ `...1/N*sum(theExp,1)'*ySum` | 9,064 | 0.242 s | 17.5% | **mostly no** |
| ├ `rhoTyVec = (dataTmp.'*theExp).'` | 9,064 | 0.111 s | 8.0% | yes (gemv) |
| ├ `[tmp,ind] = max(abs(rhoTyVec).^2./rhoNormVec)` | 9,064 | 0.050 s | 3.6% | yes |
| └ zoom `linspace` + `exp` | ~9,064 | 0.082 s | 5.9% | yes |
| `extra.T1Vec = 1:5000` | 4,532 | 0.015 s | 1.1% | **no** |

**~74% of the fit was recomputing voxel-independent values.**

### Measured cost, after

`fitT1_IR` total 0.306 s. `getNLSStruct` no longer appears in the profile at all — 4,532 calls
became 1. `rdNlsPr` is 0.291 s, of which the surviving hot lines are the gemv (0.087 s, 30%), the
zoom `linspace` (0.065 s, 22%), the argmax (0.041 s, 14%) and the centering multiply (0.021 s, 7%).
The `theExp(order,:)` copy has vanished entirely, confirming MATLAB's copy-on-write elides
`theExp = nlsS.sortedTheExp` rather than duplicating the matrix.

### Why each change is bit-exact

This is the load-bearing part of the review.

**(1) `nlsS` cache.** Same `getNLSStruct` call with the same inputs produces the same struct; only
the number of times it runs changes. The key is `T_IR`. The hardcoded T1 range does not need to be
in the key because MATLAB clears a function's persistent variables when the file is edited, so the
cache cannot outlive a change to it.

**(2) `theExpSum`.** The centering term was written `1/nlsS.N*sum(nlsS.theExp,1)'*ySum`, which MATLAB
evaluates left-to-right as `((1/N) * colSum) * ySum`. Replacing `sum(nlsS.theExp,1)'` with a
precomputed `nlsS.theExpSum` leaves the expression form — and therefore the association and the
rounding — untouched.

**(3) `sortedTheExpSum` — the subtle one.** It is summed over the rows of `sortedTheExp`, *not*
reused from `theExpSum`. Floating-point addition is not associative, so summing the same nine values
in a different row order is not guaranteed to produce the same bits. Reusing the unpermuted sum
would have been mathematically correct and bitwise wrong. With this protocol the TIs are already
ascending, so the permutation is the identity and the two happen to coincide — but the code must not
depend on that.

**(4) The zoom pass is deliberately left alone.** It rebuilds a small 9 x 21 `theExp` per voxel whose
column sums genuinely cannot be hoisted, so `sum(theExp,1)'` there is unchanged.

**(5) What was NOT done, and why.** Batching voxels so the per-voxel `gemv` becomes a single `gemm`
is the natural next optimisation and is *not* safe here. The cross-check below shows `ra`/`rb`/`res`
already drift by ~1 ULP against a `FitResults.mat` generated in a different session, almost certainly
from Accelerate's kernel selection in `dataTmp.'*theExp`. We do not control BLAS summation order the
way we control the surrounding MATLAB, so any change to the shape of that call risks perturbing the
output even though it is mathematically identical. All five changes in this PR leave the BLAS call
untouched.

### A dead end, recorded so it is not repeated

`linspace` showed up as 0.065 s (~21% of `fitT1_IR`) after the hoists — it is an m-file whose argument
validation dominates its cost at n = 21, and the zoom calls it twice per voxel. Replacing it with an
inline helper that reproduces its arithmetic exactly (including the left-to-right association of
`((0:n-1).*(d2-d1))./(n-1)` and the exact endpoint assignment) **was bit-identical but delivered no
measurable speedup**: 0.25 s -> 0.26 s Magnitude, 0.18 s -> 0.17 s Complex, both within noise. The
profiled time did drop, because most of that 0.065 s was per-line profiler instrumentation on
`linspace`'s internals rather than real work. It was reverted: freezing a MathWorks-internal formula
into qMRLab is not worth zero measured gain. Treat profiled hot spots in small, very frequently
called m-files with suspicion.

### Verification performed

- `bench_ir.m` harness: best-of-3 after warm-up, cross-validated against `FitData`'s own `Fit.Time`,
  with a hard assertion that `nnz(Fit.computed)` equals the mask voxel count
- Bitwise map comparison via `typecast(...,'uint64')` for both methods: **0 bit-differences** across
  `T1`, `ra`, `rb`, `res`, `idx`, NaN footprint identical
- Cross-check against the shipped demo `FitResults.mat` is unchanged by this PR (still 0 bit-diffs on
  `T1` and `idx`; the pre-existing ~1 ULP drift on `ra`/`rb`/`res` against that file neither grew nor
  shrank, confirming these changes moved nothing)

### External validation

The same demo dataset was fitted by `qmrust`, an independent Rust implementation of the same Barral
algorithm, on bitwise-identical input. Agreement on `T1`: **99.96% of Magnitude voxels within one
1 ms grid step** (69.1% exact, median difference 0 ms, maximum 1.5 ms). The residual disagreements
are the argmax landing on an adjacent grid point, traceable to unit representation — qMRLab searches
integer milliseconds `1:5000` while `qmrust` searches `0.001:0.001:5.0` seconds, and neither `0.001`
nor `0.350` is exactly representable in binary, so the two grids differ in the low bits and near-ties
can tip either way. This is a property of the units, not of either implementation.

</details>
