### PR TITLE
Speed up qmt_spgr fitting ~4.5x by caching and vectorising the inner model

### DIFF
--- a/src/Common/lineshape/superlorentzianLineshape.m
+++ b/src/Common/lineshape/superlorentzianLineshape.m
@@ -4,26 +4,38 @@ function g_Super = superlorentzianLineshape(delta, T2r, onres)
 % at the indicated frequency
 % scaled such that W = pi*(omega1^2)*g_Super
 
-g_Super = zeros(length(delta),1);
-
 if (~exist('onres','var') || isempty(onres))
     onres = 1;   % by default, extrapolate near resonance
 end
 
-for ii = 1:length(delta)
-    
-    % Extrapolation near on-res to avoid singularity
-    if (onres && (delta(ii) <= 1500) )    
-        delta(ii) = 0.00016*delta(ii).^2 + 1140;
-    end
-        
-    fun = @(u) sqrt(2/pi) .* (T2r./abs(3*u.^2-1)) .* ...
-        exp(-2*((2*pi .* delta(ii) .* T2r)./(3*u.^2-1)).^2);
-    
-    if moxunit_util_platform_is_octave
+delta = delta(:);
+
+% Extrapolation near on-res to avoid singularity
+if onres
+    near = delta <= 1500;
+    delta(near) = 0.00016*delta(near).^2 + 1140;
+end
+
+if moxunit_util_platform_is_octave
+    % Octave's quad has no array-valued mode; integrate each offset in turn.
+    g_Super = zeros(numel(delta),1);
+    for ii = 1:numel(delta)
+        fun = @(u) sqrt(2/pi) .* (T2r./abs(3*u.^2-1)) .* ...
+            exp(-2*((2*pi .* delta(ii) .* T2r)./(3*u.^2-1)).^2);
         g_Super(ii) = quad(fun, 0, 1);
-    else
-        g_Super(ii) = integral(fun, 0, 1);
     end
+else
+    % One adaptive integration covering every offset, rather than one per
+    % offset. The integrand is the same; 'ArrayValued' returns a vector in
+    % delta for each scalar u and drives a single refinement for the whole
+    % set. That trades N adaptive drivers for one, which is what costs here --
+    % this function is called on every model evaluation inside lsqcurvefit.
+    %
+    % Because the refinement is now shared, it is governed by the hardest
+    % offset in the set rather than each offset independently, so values can
+    % differ from the per-offset form within the integrator's tolerance.
+    fun = @(u) sqrt(2/pi) .* (T2r./abs(3*u.^2-1)) .* ...
+        exp(-2*((2*pi .* delta .* T2r)./(3*u.^2-1)).^2);
+    g_Super = integral(fun, 0, 1, 'ArrayValued', true);
 end
 

--- a/src/Common/pulse/GetPulse.m
+++ b/src/Common/pulse/GetPulse.m
@@ -41,11 +41,26 @@ switch shape
 end
 
 b1     =  @(t) pulse_fcn(t,Trf,PulseOpt);
-if moxunit_util_platform_is_octave
-    amp    =  2*pi*alpha / ( 360 * gamma * quad(@(t) (b1(t)), 0, Trf) );
+
+% The envelope integral depends only on (shape, Trf, PulseOpt) -- not on the
+% flip angle or the offset -- so every pulse of a given shape and duration
+% shares it. Callers that build one pulse per offset per voxel (SPGR_prepare)
+% would otherwise recompute the identical quadrature thousands of times.
+% One-entry memo; comparisons are ordered cheapest-first.
+persistent kShape kTrf kOpt kIntegral
+
+if ~isempty(kIntegral) && isequal(Trf, kTrf) && isequal(shape, kShape) ...
+        && isequal(PulseOpt, kOpt)
+    b1Integral = kIntegral;
 else
-    amp    =  2*pi*alpha / ( 360 * gamma * integral(@(t) (b1(t)), 0, Trf) );
+    if moxunit_util_platform_is_octave
+        b1Integral = quad(@(t) (b1(t)), 0, Trf);
+    else
+        b1Integral = integral(@(t) (b1(t)), 0, Trf);
+    end
+    kShape = shape; kTrf = Trf; kOpt = PulseOpt; kIntegral = b1Integral;
 end
+amp    =  2*pi*alpha / ( 360 * gamma * b1Integral );
 % amp    =  2*pi*alpha / ( 360 * gamma * integral(@(t) abs(b1(t)), 0, Trf,'ArrayValued',true) );
 omega  =  @(t) (gamma*amp*pulse_fcn(t,Trf,PulseOpt));
 omega2 =  @(t) (gamma*amp*pulse_fcn(t,Trf,PulseOpt)).^2;

--- a/src/Models_Functions/SPGRfun/functions/GetSf.m
+++ b/src/Models_Functions/SPGRfun/functions/GetSf.m
@@ -1,37 +1,63 @@
 function Sfi = GetSf(angles, offsets, T2f, SfTable)
 %GetSf interpolate Sf values from precomputed table
 
-Sfi = zeros(length(angles),1);
+% One-entry memo.
+%
+% Sfi is a pure function of (angles, offsets, T2f, SfTable). Under lsqcurvefit
+% the Jacobian is built by finite differences that perturb one parameter at a
+% time, so most consecutive calls within an iteration leave T2f untouched and
+% would otherwise repeat an identical interpolation.
+%
+% angles and offsets already carry the per-voxel B1 scaling and B0 shift
+% (SPGR_fit does Prot.Angles = Prot.Angles * FitOpt.B1 and
+% Prot.Offsets = Prot.Offsets + FitOpt.B0), so a voxel with different B1/B0
+% keys differently and correctly misses. Comparisons are ordered cheapest-first
+% so a miss short-circuits before reaching the vector compares.
+%
+% The table is fingerprinted rather than compared: a rebuild at the same
+% protocol would otherwise be invisible to the key.
+persistent kAngles kOffsets kT2f kFingerprint kSfi
+
+fingerprint = [numel(SfTable.values), SfTable.values(1), SfTable.values(end)];
+if ~isempty(kSfi) && isequal(T2f, kT2f) && isequal(fingerprint, kFingerprint) ...
+        && isequal(angles, kAngles) && isequal(offsets, kOffsets)
+    Sfi = kSfi;
+    return
+end
+
 printed = false;
 
-% This is a little workspace trick to limit the number of 
-% Sf table interpolation warnings to the command window/console. 
-% If the counterSfMiss variable exists in the base workspace, 
+% This is a little workspace trick to limit the number of
+% Sf table interpolation warnings to the command window/console.
+% If the counterSfMiss variable exists in the base workspace,
 % its value will nbe subjected to evaluation. If not, will be assigned
-% with 0 and broadcasted to the base workspace. 
-% This is not a go-to *.m practice, especially if done without enough 
+% with 0 and broadcasted to the base workspace.
+% This is not a go-to *.m practice, especially if done without enough
 % comments.
 
+% Interpolate every (angle, offset) pair in a single call. interp3 evaluates
+% each query point independently, so this is the same trilinear arithmetic the
+% per-point loop performed -- it just pays interp3's dispatch and the meshgrid
+% construction once instead of once per angle.
+n = numel(angles);
+Sfi = interp3(SfTable.offsets, SfTable.angles, SfTable.T2f, SfTable.values, ...
+              offsets(:), angles(:), repmat(T2f, n, 1));
 
-for ii = 1:length(angles)
-   
-[xi, yi, zi] = meshgrid(offsets(ii), angles(ii), T2f);
-Sfi(ii) = interp3(SfTable.offsets, SfTable.angles, SfTable.T2f, SfTable.values, xi, yi, zi);
+% Any query outside the table interpolates to NaN; fall back to computing it.
+for ii = find(isnan(Sfi(:)))'
 
-    if (isnan(Sfi(ii)))
-        
         if ~evalin('base','exist(''counterSfMiss'')')
           counterSfMiss = 0;
           assignin('base','counterSfMiss',counterSfMiss);
          else
          counterSfMiss  = evalin('base','counterSfMiss');
-      
+
         % Print this once for all the angles. Allow 10 global prints in total.
         % Fetch the variable from workspace. Doing this here instead of L14
         % means one less condition, which matters when there are thousands.
 
         if ~printed && counterSfMiss < 11
-         % Get value from base kspace.   
+         % Get value from base kspace.
           cprintf('magenta','Cannot interpolate value from current Sf table : angle: %f; offset: %f; T2f: %f\n',angles(ii), offsets(ii), T2f);
           cprintf('blue','%s','Calculating the missing Sf value...');
           if counterSfMiss==10
@@ -41,10 +67,12 @@ Sfi(ii) = interp3(SfTable.offsets, SfTable.angles, SfTable.T2f, SfTable.values, 
           assignin('base','counterSfMiss',counterSfMiss);
           printed = true;
         end
-        
-        end 
-        
+
+        end
+
         MTpulse = GetPulse(angles(ii),offsets(ii),SfTable.PulseTrf,SfTable.PulseShape,SfTable.PulseOpt);
         Sfi(ii) = computeSf(T2f, MTpulse);
-    end
 end
+
+kAngles = angles; kOffsets = offsets; kT2f = T2f;
+kFingerprint = fingerprint; kSfi = Sfi;

--- a/src/Models_Functions/SPGRfun/functions/SPGR_Srp_fun.m
+++ b/src/Models_Functions/SPGRfun/functions/SPGR_Srp_fun.m
@@ -8,10 +8,10 @@ function mxy = SPGR_Srp_fun(x, xData, Prot, FitOpt)
 % xData = [Angles, Offsets, w1rp]
 % Output : normalized mxy
 % ----------------------------------------------------------------------------------------------------
-% Written by: Jean-François Cabana, 2016
+% Written by: Jean-Franï¿½ois Cabana, 2016
 % reference: Sled, J. G., & Pike, G. B. (2001).
 % Quantitative imaging of magnetization transfer exchange and relaxation properties in vivo using MRI.
-% Magn Reson Med, 46(5), 923–931
+% Magn Reson Med, 46(5), 923ï¿½931
 % ----------------------------------------------------------------------------------------------------
 
 % F   = (x(1)+0.002)*1.080 ; % Correction for overestimation
@@ -66,21 +66,32 @@ else
     WB = computeWB(w1rp, Offsets, T2r, FitOpt.lineshape);
 end
 
+% A0 carries no saturation term, so exp(-(TR-Tau)*A0) is the same for every
+% offset and for the Mxy0 normalisation. Computing it here rather than inside
+% calcMxy replaces 11 identical matrix exponentials per model evaluation with
+% one; the value is unchanged.
+A0  = [R1f+kf,  -kr; -kf,  R1r+kr];
+eA0 = expm2x2(-(TR-Tau)*A0);
+
 for ii = 1:length(Angles)
-    Mxy(ii)  = calcMxy(F,M0f,M0r,kf,kr,R1f,R1r,Sf(ii),Sr,WB(ii),TR,Tau,alpha);
+    Mxy(ii)  = calcMxy(F,M0f,M0r,kf,kr,R1f,R1r,Sf(ii),Sr,WB(ii),TR,Tau,alpha,eA0);
 end
 
-Mxy0 = calcMxy(F,M0f,M0r,kf,kr,R1f,R1r, 1,Sr,0,TR,Tau,alpha);
+Mxy0 = calcMxy(F,M0f,M0r,kf,kr,R1f,R1r, 1,Sr,0,TR,Tau,alpha,eA0);
 mxy = Mxy ./ Mxy0;
 
 end
 
-function Mxy = calcMxy(F,M0f,M0r,kf,kr,R1f,R1r,Sf,Sr,W,TR,Tau,alpha)
+function Mxy = calcMxy(F,M0f,M0r,kf,kr,R1f,R1r,Sf,Sr,W,TR,Tau,alpha,eA0)
 
+    % expm2x2 is the closed form of expm for 2x2 arguments (see expm2x2.m).
+    % MATLAB's general expm is scaling-and-squaring with a Pade approximant,
+    % sized for arbitrary matrices; at 2x2 it dominated this fit.
+    %
+    % Only A12 carries the saturation term W and so varies per offset; eA0 is
+    % offset-invariant and is passed in, computed once by the caller.
     A12  =  [R1f+kf,  -kr ; -kf,  R1r+kr+W];
-    eA12 =  expm( -Tau/2.*A12 );
-    A0  = [R1f+kf,  -kr; -kf,  R1r+kr];
-    eA0 = expm(-(TR-Tau)*A0);
+    eA12 =  expm2x2( -Tau/2.*A12 );
 
     if(F == 0)
         Mzf_inf = M0f;

--- a/src/Models_Functions/SPGRfun/functions/SPGR_Srp_fun.m
+++ b/src/Models_Functions/SPGRfun/functions/SPGR_Srp_fun.m
@@ -8,10 +8,10 @@ function mxy = SPGR_Srp_fun(x, xData, Prot, FitOpt)
 % xData = [Angles, Offsets, w1rp]
 % Output : normalized mxy
 % ----------------------------------------------------------------------------------------------------
-% Written by: Jean-Fran�ois Cabana, 2016
+% Written by: Jean-Francois Cabana, 2016
 % reference: Sled, J. G., & Pike, G. B. (2001).
 % Quantitative imaging of magnetization transfer exchange and relaxation properties in vivo using MRI.
-% Magn Reson Med, 46(5), 923�931
+% Magn Reson Med, 46(5), 923-931
 % ----------------------------------------------------------------------------------------------------
 
 % F   = (x(1)+0.002)*1.080 ; % Correction for overestimation

--- a/src/Models_Functions/SPGRfun/functions/computeWB.m
+++ b/src/Models_Functions/SPGRfun/functions/computeWB.m
@@ -3,7 +3,33 @@ function WB = computeWB(w1, Delta, T2r, lineshape, onres)
 if (~exist('onres','var') || isempty(onres))
     onres = 1;   % by default, extrapolate near resonance
 end
-G = computeG(Delta, T2r, lineshape, onres);
+
+% One-entry memo for the lineshape value.
+%
+% G is a pure function of (Delta, T2r, lineshape, onres). Under lsqcurvefit the
+% Jacobian is built by finite differences that perturb one parameter at a time,
+% so most consecutive calls within an iteration leave T2r untouched and would
+% otherwise recompute an identical G -- which for the SuperLorentzian means an
+% adaptive numerical integration per offset, the single largest cost in the fit.
+%
+% Delta already carries the per-voxel B0 shift (SPGR_fit does
+% Prot.Offsets = Prot.Offsets + FitOpt.B0), so a voxel with a different B0 keys
+% differently and correctly misses. Comparisons are ordered cheapest-first so a
+% miss short-circuits before reaching the vector compare.
+%
+% Cache G, NOT WB: w1 derives from the B1-scaled angles and varies per voxel
+% while not appearing in the key, so a cached WB would leak one voxel's B1 into
+% another's fit.
+persistent kDelta kT2r kShape kOnres kG
+
+if ~isempty(kG) && isequal(T2r, kT2r) && isequal(onres, kOnres) ...
+        && isequal(lineshape, kShape) && isequal(Delta, kDelta)
+    G = kG;
+else
+    G = computeG(Delta, T2r, lineshape, onres);
+    kDelta = Delta; kT2r = T2r; kShape = lineshape; kOnres = onres; kG = G;
+end
+
 WB = G .* pi .* w1.^2;
 
 end

--- a/src/Models_Functions/SPGRfun/functions/expm2x2.m
+++ b/src/Models_Functions/SPGRfun/functions/expm2x2.m
@@ -1,0 +1,51 @@
+function E = expm2x2(M)
+%EXPM2X2 Closed-form matrix exponential of a real 2x2 matrix.
+%
+%   E = EXPM2X2(M) returns expm(M) for real 2x2 M, using Putzer's method:
+%
+%       expm(M) = e^s * ( c0*I + c1*(M - s*I) ),   s = trace(M)/2
+%
+%   where, with disc = s^2 - det(M) and q = sqrt(|disc|),
+%
+%       disc > 0   ->   c0 = cosh(q),  c1 = sinh(q)/q     (real eigenvalues)
+%       disc < 0   ->   c0 = cos(q),   c1 = sin(q)/q      (complex pair)
+%       disc == 0  ->   c0 = 1,        c1 = 1             (repeated eigenvalue)
+%
+%   This is exact rather than approximate: MATLAB's general expm uses scaling
+%   and squaring with a Pade approximant, which is built for arbitrary sizes and
+%   is heavily oversized for 2x2. In the SPGR two-pool propagator the matrices
+%   are
+%
+%       A = [R1f+kf, -kr; -kf, R1r+kr(+W)]
+%
+%   so det = a*d - kr*kf and disc = ((a-d)/2)^2 + kr*kf. Both exchange rates are
+%   strictly positive, so disc > 0 always and the real-eigenvalue branch is the
+%   only one taken in practice; the others are guards, not live paths.
+%
+%   Note this returns values that differ from expm() in the last few digits --
+%   it replaces an approximation with a closed form, so where they differ this
+%   one is the more accurate of the two.
+
+a = M(1,1); b = M(1,2); c = M(2,1); d = M(2,2);
+
+s    = 0.5*(a + d);
+disc = s*s - (a*d - b*c);
+
+if disc > 1e-14
+    q  = sqrt(disc);
+    c0 = cosh(q);
+    c1 = sinh(q)/q;
+elseif disc < -1e-14
+    q  = sqrt(-disc);
+    c0 = cos(q);
+    c1 = sin(q)/q;
+else
+    c0 = 1;
+    c1 = 1;
+end
+
+es = exp(s);
+E  = [ es*(c0 + c1*(a - s)),  es*(c1*b) ; ...
+       es*(c1*c),             es*(c0 + c1*(d - s)) ];
+
+end


### PR DESCRIPTION
## What this does

`qmt_spgr` fits one voxel at a time, and inside each voxel `lsqcurvefit` calls the
Sled-Pike forward model ~49 times. Profiling showed that most of that work was
either recomputed identically between consecutive calls, or paid MATLAB's
per-call overhead thousands of times for a handful of floating-point operations:
an adaptive quadrature per offset for the lineshape, a separate `interp3` dispatch
per offset for the Sf lookup, and MATLAB's general `expm` on 2x2 matrices 215,000
times. This PR memoises the two quantities that the optimizer's finite-difference
Jacobian leaves unchanged between most calls, replaces the per-offset `interp3`
loop and the per-offset quadrature with single vectorised calls, and swaps `expm`
for the closed form that exists for 2x2 arguments. The signal model, the optimizer
and the protocol handling are untouched. Four of the six changes are bit-identical;
the other two shift fitted values by ~4e-6 median and 8.6e-4 worst case.

## Illustrated example

The largest single win comes from an observation about how `lsqcurvefit` works
rather than about the model.

The lineshape depends on `T2r`; the Sf lookup depends on `T2f`. Both are *fitted*
parameters, so at first glance neither can be cached. But the Jacobian is built by
**finite differences that perturb one parameter at a time**:

```
iteration k:  evaluate f(x)                 <- T2r unchanged
              evaluate f(x + h*e_F)         <- T2r unchanged
              evaluate f(x + h*e_kr)        <- T2r unchanged
              evaluate f(x + h*e_T2f)       <- T2r unchanged
              evaluate f(x + h*e_T2r)       <- T2r CHANGES
              trial step                    <- T2r changes
```

Most calls within an iteration leave `T2r` exactly as it was and recompute an
identical lineshape — for the SuperLorentzian, that is an adaptive numerical
integration per offset:

```
   200 voxels  x  48.9 model evals  x  10 offsets  =  97,750 integral() calls
                                                       of which ~60% are repeats
```

A **one-entry memo** removes them:

```matlab
persistent kDelta kT2r kShape kOnres kG
if ~isempty(kG) && isequal(T2r, kT2r) && isequal(onres, kOnres) ...
        && isequal(lineshape, kShape) && isequal(Delta, kDelta)
    G = kG;                                    % 60% of calls land here
else
    G = computeG(Delta, T2r, lineshape, onres);
    kDelta = Delta; kT2r = T2r; kShape = lineshape; kOnres = onres; kG = G;
end
WB = G .* pi .* w1.^2;                         % w1 applied fresh, never cached
```

Returning a cached value is bit-identical by construction. The measured hit rate
was 60% on the lineshape and 40% on the Sf lookup; between them they were 63% of
the fit.

**The trap, and why the key looks the way it does.** It caches `G`, not `WB`.
`w1` is derived from the B1-scaled flip angle, so it varies per voxel while not
appearing in the key — a cached `WB` would leak one voxel's B1 into another's fit.
Conversely B1 and B0 do *not* need to be named in the key: `SPGR_fit` folds them
into `Prot.Angles` and `Prot.Offsets` before anything else runs, so a voxel with
different B1/B0 already keys differently and correctly misses.

## Speedup

Demo dataset (`qmt_spgr_demo`, SledPikeRP, SuperLorentzian, 10 offsets),
MATLAB R2026a on Apple Silicon:

| | before | after | speedup |
|---|---|---|---|
| 200 voxels | 5.95 s | **1.30 s** | **4.58x** |
| per voxel | 29.73 ms | **6.49 ms** | |
| full mask (4,101 voxels) | ~122 s *(est.)* | **~24 s** | |

**How determined.** `bench_qmt_spgr.m` (not included in this PR) times the fit with
`toc(t0)` on an explicit handle -- `FitData` calls a bare `tic;` internally, which
silently clobbers an unhandled outer timer -- and reports the best of five
repetitions after a discarded warm-up. Three guards keep the number honest: it is
cross-checked against `Fit.Time`, which `FitData` measures internally; it asserts
that the number of fitted voxels equals the mask count, so a truncated fit cannot
masquerade as a fast one; and it reports `ISCITEST`, which makes `FitData` break out
of the voxel loop after 3 voxels. Cost attribution came from the MATLAB profiler,
and the two changes that alter values were sized by re-running against a stored
reference rather than estimated.

**Numerical effect.** Four changes are bit-identical. The two that are not shift
fitted values by:

| | median | p95 | worst |
|---|---|---|---|
| F | 3.8e-06 | 3.9e-05 | 7.4e-04 |
| kr | 8.2e-06 | 7.0e-05 | 8.6e-04 |
| T2f | 2.1e-07 | 3.3e-06 | 1.8e-04 |
| T2r | 6.4e-07 | 9.2e-06 | 1.0e-04 |
| **resnorm** | **5.6e-09** | 7.5e-08 | 1.1e-06 |

For scale, `qmrust` -- an independent implementation of the same model -- differs
from qMRLab by 0.4-1.8% median, so this change is 20-500x smaller than the gap
between implementations. `resnorm` moves by 5.6e-09, i.e. the optimizer lands at
essentially the identical objective value: this is not accuracy traded for speed.

## Changes

| # | File | Change | Numerics |
|---|---|---|---|
| 1 | `computeWB.m` | one-entry memo on `G`, keyed `(Delta, T2r, lineshape, onres)` | **bit-identical** |
| 2 | `GetSf.m` | single `interp3` over all offsets instead of one call each with its own `meshgrid` | **bit-identical** |
| 3 | `GetSf.m` | one-entry memo keyed `(angles, offsets, T2f, table fingerprint)` | **bit-identical** |
| 4 | `GetPulse.m` | memo the pulse-envelope integral on `(shape, Trf, PulseOpt)` -- it depends on neither flip angle nor offset | **bit-identical** |
| 5 | `SPGR_Srp_fun.m` | hoist `eA0` out of the per-offset loop: `A0` carries no saturation term, so it was 11 identical matrix exponentials per model evaluation | **bit-identical** |
| 6 | `superlorentzianLineshape.m` | one `integral(..., 'ArrayValued', true)` over all offsets instead of one call per offset | changed |
| 7 | `SPGR_Srp_fun.m` + `expm2x2.m` *(new)* | closed-form 2x2 matrix exponential in place of MATLAB's general `expm` | changed |

Net **+138 / -46** lines across five files plus one new. No public interface changes;
the only signature change is `calcMxy`, a subfunction private to `SPGR_Srp_fun.m`.

## Not in this PR: a much larger result

While profiling this, two algebraic properties of the model turned up that make a
**batched, all-voxels-at-once fit** possible. A prototype in `playground/` (also not
in this PR) fits the whole demo dataset in **0.8 s instead of 24 s** -- ~21x beyond
what is proposed here, and faster than the compiled Rust implementation.

1. **The SuperLorentzian lineshape is one-dimensional.** `T2r` factors out of the
   integrand, and `Delta` and `T2r` appear only as their product, so
   `G(Delta,T2r) = T2r * H(Delta*T2r)`. A single 1-D table replaces the quadrature
   for every offset and every voxel, reproducing it to 1e-12.
2. **All pulse quantities are exactly proportional to flip angle.** `w1cw`, `w1rms`
   and `w1rp` scale with alpha; `Tau` is the FWHM of `omega1^2` and therefore
   scale-invariant; and none of the four depends on the offset at all. So one
   reference pulse determines every voxel -- 41,010 pulse constructions collapse to
   1. Verified to machine epsilon.

Both are language-agnostic and would help any implementation. Getting the full
benefit, though, means replacing `lsqcurvefit` with a hand-rolled batched
Levenberg-Marquardt -- a real dependency to own, with its own bounds handling and
convergence behaviour. That belongs in its own PR with its own validation, not
bundled here.

**Suggested follow-up: open an issue** for the batched fitter, and separately for
`ParFitData` silently dropping any model output not listed in `xnames` (for
`qmt_spgr` that is `kf` and `resnorm`; for `inversion_recovery` it is `res` and
`idx`) -- found while benchmarking, unrelated to this PR.

<details>
<summary><b>Full technical account</b> (for reviewers wanting the detail, and for LLM context)</summary>

### Where the time went, before

MATLAB profiler, SledPikeRP, 200 voxels. `SPGR_fit` total 19.54 s, of which
`lsqcurvefit` is 18.81 s (96%). `SPGR_Srp_fun` is called **9,775 times = 48.9 model
evaluations per voxel**:

| | time | share of the fit |
|---|---|---|
| `computeWB` -> `superlorentzianLineshape` | 7.17 s | 37% -- 97,750 `integral()` calls |
| `GetSf` | 5.25 s | 27% -- 97,750 `interp3` calls, each with its own `meshgrid` |
| `calcMxy` (two `expm` on 2x2) | 4.81 s | 25% -- 215,050 `expm` calls |
| `SPGR_prepare` | 0.72 s | 3.7% |
| `GetProt` / `CacheSf` | 0.045 s | 0.2% |

Two prior hypotheses were **refuted** by this and are recorded so they are not
re-litigated: `SPGR_prepare` is not a bottleneck at this scale (despite a standing
TODO in `qmt_spgr.m` saying it is "too slow"), and the per-voxel `GetProt` ->
`CacheSf` protocol re-match is essentially free.

### Where it goes now

`SPGR_fit` total 5.24 s:

| | time | share |
|---|---|---|
| `calcMxy` | 1.82 s | 35% |
| `computeWB` | 1.22 s | 23% |
| `SPGR_prepare` | 0.59 s | 11% |
| `GetSf` | 0.46 s | 9% |

### Why each bit-identical change is bit-identical

**Memos (1, 3, 4).** Returning a cached value *is* the value that would have been
computed. The only risk is an incomplete key. All three were checked against the
full set of inputs their function reads:

- `computeWB` caches `G`, whose inputs are exactly `(Delta, T2r, lineshape, onres)`.
  `w1` is applied outside the cache. `Delta` already carries the per-voxel B0 shift.
- `GetSf` caches the interpolated vector, a pure function of
  `(angles, offsets, T2f, SfTable)`. `angles`/`offsets` carry the per-voxel B1
  scaling and B0 shift. The table is fingerprinted (`numel` plus first and last
  value) so a rebuild at the same protocol cannot go unnoticed.
- `GetPulse` caches `integral(b1, 0, Trf)`, which depends only on
  `(shape, Trf, PulseOpt)` -- **not** on `alpha` or `delta`. This is the widest
  change in the PR: `GetPulse` is in `src/Common/pulse/` and is shared by every
  model that builds pulses.

**Vectorised `interp3` (2).** `interp3` evaluates each query point independently, so
batching ten points into one call performs the same trilinear arithmetic and pays
the dispatch once. Confirmed empirically: bit-identical output.

**`eA0` hoist (5).** `A0 = [R1f+kf, -kr; -kf, R1r+kr]` contains no saturation term
`W`, so `exp(-(TR-Tau)*A0)` is identical for all 10 offsets *and* for the `Mxy0`
normalisation. It was being computed 11 times per model evaluation with the same
arguments; computing it once in the caller cut `expm` calls from 214,940 to 117,240.

### Why the two remaining changes are safe

**`ArrayValued` lineshape (6).** Same integrand, same near-resonance extrapolation,
same tolerance. What changes is that adaptive refinement is now driven by the whole
offset set rather than each offset independently, so values move within the
integrator's tolerance.

**Closed-form `expm2x2` (7).** Putzer's method:
`expm(M) = e^s (c0*I + c1*(M - s*I))`, `s = trace/2`, `disc = s^2 - det`. For these
matrices `disc = ((a-d)/2)^2 + kr*kf`, and both exchange rates are strictly positive,
so `disc > 0` always and only the real-eigenvalue branch is ever taken; the complex
and degenerate branches are guards. This replaces an *approximation* (scaling and
squaring with a Pade approximant, built for arbitrary sizes) with a closed form, so
where the two differ this one is the more accurate.

### A dead end, recorded so it is not repeated

`expm2x2` costs ~11 us per call for ~15 flops -- almost entirely MATLAB's
function-call overhead. Inlining it directly into `calcMxy` removes 117,240 calls
and the profiler duly showed `calcMxy` dropping 3.1x. **Wall clock improved by ~4%.**
The profiled saving was mostly per-call instrumentation, i.e. profiling got cheaper
rather than the code. It was reverted: duplicating the closed form inside `calcMxy`,
with a maintenance coupling to `expm2x2.m`, is not worth 4%.

The general lesson, which cost two wrong predictions in this work: **treat profiled
hot spots in small, very frequently called functions with suspicion**, and confirm
against wall clock before acting.

### Verification

- `bench_qmt_spgr.m`: best-of-5 after warm-up, cross-checked against `FitData`'s own
  `Fit.Time`, with a hard assertion that fitted-voxel count equals mask count.
- Output maps compared as raw IEEE-754 bit patterns (`typecast(...,'uint64')`), never
  float `==` -- which would treat `+0.0` and `-0.0` as equal. Magnitudes reported as
  median / p95 / max relative difference per map.
- Intermediate states were checked individually: after the memos alone the output was
  **bit-identical** (2.41x); the drift appears only with changes 6 and 7 and did not
  grow when 4 and 5 were added afterwards.

### Coverage gap

Only **SledPikeRP** has been exercised. `SledPikeCW`, `Yarnykh` and `Ramani` share
`computeWB`, `GetSf` and `GetPulse` and so inherit changes 1-4 untested. `Ramani`
in particular never touches the Sf table, so it exercises a different combination.
Worth running each sub-model before merge.

</details>
