### PR TITLE
CI bug: Don't fail on tests that are incomplete because they were skipped by an assumption

### DIFF
--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -106,8 +106,8 @@ jobs:
             qMRLabVer;
             [testResults, coverageResults] = runtests('${{ matrix.tests }}', 'ReportCoverageFor', 'src', 'IncludeSubfolders', true);
             coverageResults.generateCoberturaReport('${{ matrix.report }}');
-            allPassed = all([testResults.assertSuccess().Passed]);
-            exit(~allPassed);
+            % Don't fail on tests that are incomplete because they were skipped by an assumption
+            exit(any([testResults.Failed]));
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
Failure log that raised this issue:

```
2026-08-12T18:06:08.3811311Z -----------------------------------------------
2026-08-12T18:06:08.3859619Z qMRLab version: v2.4.2
2026-08-12T18:06:10.8147751Z Running downloadData_Test
2026-08-12T18:06:11.0501285Z .curl: /opt/hostedtoolcache/MATLAB/2026.1.999/x64/bin/glnxa64/libcurl.so.4: version `CURL_OPENSSL_4' not found (required by curl)
2026-08-12T18:06:11.4726428Z 
2026-08-12T18:06:11.4727177Z ================================================================================
2026-08-12T18:06:11.4727895Z downloadData_Test/test_method(method=curl) was filtered.
2026-08-12T18:06:11.4728417Z ================================================================================
2026-08-12T18:06:11.5251103Z .GNU Wget 1.21.4 built on linux-gnu.
2026-08-12T18:06:11.5252379Z 
2026-08-12T18:06:11.5252676Z -cares +digest -gpgme +https +ipv6 +iri +large-file -metalink +nls 
2026-08-12T18:06:11.5252974Z +ntlm +opie +psl +ssl/openssl 
2026-08-12T18:06:11.5253106Z 
2026-08-12T18:06:11.5253167Z Wgetrc: 
2026-08-12T18:06:11.5253282Z     /etc/wgetrc (system)
2026-08-12T18:06:11.5253514Z Locale: 
2026-08-12T18:06:11.5253886Z     /usr/share/locale 
2026-08-12T18:06:11.5254012Z Compile: 
2026-08-12T18:06:11.5254156Z     gcc -DHAVE_CONFIG_H -DSYSTEM_WGETRC="/etc/wgetrc" 
2026-08-12T18:06:11.5254422Z     -DLOCALEDIR="/usr/share/locale" -I. -I../../src -I../lib 
2026-08-12T18:06:11.5254673Z     -I../../lib -Wdate-time -D_FORTIFY_SOURCE=3 -DHAVE_LIBSSL -DNDEBUG 
2026-08-12T18:06:11.5254934Z     -g -O2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer 
2026-08-12T18:06:11.5255192Z     -ffile-prefix-map=/build/wget-XIclAW/wget-1.21.4=. -flto=auto 
2026-08-12T18:06:11.5255464Z     -ffat-lto-objects -fstack-protector-strong -fstack-clash-protection 
2026-08-12T18:06:11.5255719Z     -Wformat -Werror=format-security -fcf-protection 
2026-08-12T18:06:11.5255983Z     -fdebug-prefix-map=/build/wget-XIclAW/wget-1.21.4=/usr/src/wget-1.21.4-1ubuntu4.3 
2026-08-12T18:06:11.5257040Z     -DNO_SSLv2 -D_FILE_OFFSET_BITS=64 -g -Wall 
2026-08-12T18:06:11.5257249Z Link: 
2026-08-12T18:06:11.5257416Z     gcc -DHAVE_LIBSSL -DNDEBUG -g -O2 -fno-omit-frame-pointer 
2026-08-12T18:06:11.5257629Z     -mno-omit-leaf-frame-pointer 
2026-08-12T18:06:11.5257831Z     -ffile-prefix-map=/build/wget-XIclAW/wget-1.21.4=. -flto=auto 
2026-08-12T18:06:11.5258097Z     -ffat-lto-objects -fstack-protector-strong -fstack-clash-protection 
2026-08-12T18:06:11.5258346Z     -Wformat -Werror=format-security -fcf-protection 
2026-08-12T18:06:11.5258602Z     -fdebug-prefix-map=/build/wget-XIclAW/wget-1.21.4=/usr/src/wget-1.21.4-1ubuntu4.3 
2026-08-12T18:06:11.5258898Z     -DNO_SSLv2 -D_FILE_OFFSET_BITS=64 -g -Wall -Wl,-Bsymbolic-functions 
2026-08-12T18:06:11.5259155Z     -flto=auto -ffat-lto-objects -Wl,-z,relro -Wl,-z,now -lpcre2-8 
2026-08-12T18:06:11.5259390Z     -luuid -lidn2 -lssl -lcrypto -lz -lpsl ../lib/libgnu.a 
2026-08-12T18:06:11.5259527Z 
2026-08-12T18:06:11.5259617Z Copyright (C) 2015 Free Software Foundation, Inc.
2026-08-12T18:06:11.5259808Z License GPLv3+: GNU GPL version 3 or later
2026-08-12T18:06:11.5259993Z <http://www.gnu.org/licenses/gpl.html>.
2026-08-12T18:06:11.5260200Z This is free software: you are free to change and redistribute it.
2026-08-12T18:06:11.5260425Z There is NO WARRANTY, to the extent permitted by law.
2026-08-12T18:06:11.5260550Z 
2026-08-12T18:06:11.5260639Z Originally written by Hrvoje Niksic <hniksic@xemacs.org>.
2026-08-12T18:06:11.5260866Z Please send bug reports and questions to <bug-wget@gnu.org>.
2026-08-12T18:06:11.7894105Z .Data has been downloaded using websave...
2026-08-12T18:06:12.5503965Z .Download successful: 559 bytes
2026-08-12T18:06:12.6243250Z .Data has been downloaded ...
2026-08-12T18:06:12.6365333Z .Please wait. Downloading data ...
2026-08-12T18:06:16.1438576Z Download successful. Unzipping data ...
2026-08-12T18:06:16.1851329Z .[Warning: Directory already exists.] 
2026-08-12T18:06:16.1869605Z [> In downloadData (line 73)
2026-08-12T18:06:16.1870403Z In downloadData_Test/test_model_demo_download (line 57)]
2026-08-12T18:06:16.1875693Z Please wait. Downloading data ...
2026-08-12T18:06:16.8449341Z Redirect: https://osf.io/mw3sq/download?version=3 -> https://osf.io/download/mw3sq/?version=3
2026-08-12T18:06:20.5182547Z Download successful: 92617 bytes
2026-08-12T18:06:20.5187981Z Download successful. Unzipping data ...
2026-08-12T18:06:20.5303651Z [Warning: Directory already exists.] 
2026-08-12T18:06:20.5325441Z [> In downloadData (line 122)
2026-08-12T18:06:20.5325779Z In downloadData_Test/test_model_demo_download (line 57)]
2026-08-12T18:06:20.6126684Z .Please wait. Downloading data ...
2026-08-12T18:06:21.3630768Z Download attempt 1 failed.
2026-08-12T18:06:21.4273249Z .
2026-08-12T18:06:21.4287279Z Done downloadData_Test
2026-08-12T18:06:21.4293687Z __________
2026-08-12T18:06:21.4296239Z 
2026-08-12T18:06:21.5733435Z Running hard_pulse_Test
2026-08-12T18:06:21.6497758Z .
2026-08-12T18:06:21.6498801Z Done hard_pulse_Test
2026-08-12T18:06:21.6500469Z __________
2026-08-12T18:06:21.6501098Z 
2026-08-12T18:06:21.7597881Z Running BlochNoMT_Test
2026-08-12T18:06:22.1649256Z .....
2026-08-12T18:06:22.1677509Z Done BlochNoMT_Test
2026-08-12T18:06:22.1707389Z __________
2026-08-12T18:06:22.1717038Z 
2026-08-12T18:06:22.1850218Z Running BlochSol_Test
2026-08-12T18:06:22.5642614Z ......
2026-08-12T18:06:22.5643903Z Done BlochSol_Test
2026-08-12T18:06:22.5644754Z __________
2026-08-12T18:06:22.5646062Z 
2026-08-12T18:06:22.5854873Z Running Bloch_Test
2026-08-12T18:06:25.9867183Z .......
2026-08-12T18:06:25.9867454Z Done Bloch_Test
2026-08-12T18:06:25.9886583Z __________
2026-08-12T18:06:25.9886854Z 
2026-08-12T18:06:25.9923995Z Running addNoise_Test
2026-08-12T18:06:26.1180571Z ......
2026-08-12T18:06:26.1181256Z Done addNoise_Test
2026-08-12T18:06:26.1181604Z __________
2026-08-12T18:06:26.1181839Z 
2026-08-12T18:06:26.1194406Z Running computeR1_Test
2026-08-12T18:06:26.1701809Z .
2026-08-12T18:06:26.1702463Z Done computeR1_Test
2026-08-12T18:06:26.1702700Z __________
2026-08-12T18:06:26.1703211Z 
2026-08-12T18:06:26.4978821Z Failure Summary:
2026-08-12T18:06:26.4978992Z 
2026-08-12T18:06:26.4979118Z      Name                                        Failed  Incomplete  Reason(s)
2026-08-12T18:06:26.4979368Z     =========================================================================================
2026-08-12T18:06:26.4979666Z      downloadData_Test/test_method(method=curl)              X       Filtered by assumption.
2026-08-12T18:06:28.9152605Z MATLAB code coverage report has been saved to:
2026-08-12T18:06:28.9152893Z  /tmp/tpab6ec7ac_4b78_4b36_aa06_f931af41c33b/index.html
2026-08-12T18:06:34.5902395Z exit status 1
```